### PR TITLE
Content Band block (issue #99) - icon list 

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -167,6 +167,40 @@ sup {
     font-size: small;
 }
 
+/* Content-band styles, icon-list variation */
+.content-band.icon-list > div {
+    align-items: start;
+    letter-spacing: var(--letter-spacing-001-em);
+}
+
+/* The individual unit of content */
+.content-band.icon-list > div > div {
+    margin-top: var(--spacer-element-05);
+}
+
+.content-band li {
+    list-style-image: url("../icons/arrow-purple.svg");
+    margin-left: var(--spacer-element-07);
+    margin-bottom: var(--spacer-element-03);
+    line-height: var(--line-height-160);
+}
+
+.content-band.icon-list h4 {
+    font-family: var(--sans-serif-font-medium);
+    font-size: var(--font-size-18);
+    line-height: var(--line-height-160);
+    font-weight: 500;
+    margin: 0;
+    letter-spacing: var(--letter-spacing-001-em);
+}
+.content-band.icon-list p {
+    font-size: var(--font-size-16);
+}
+
+.content-band.icon-list img {
+    width: auto;
+}
+
 /* Mobile */
 @media only screen and (max-width: 768px) {
     main .section > div {
@@ -177,15 +211,12 @@ sup {
     main .section-bottom .columns-2-cols h1 {
         font-size: 32px;
         line-height: 115px;
-
     }
-
 
     /* Back to top button */
     main .section.back-to-top.active[data-section-status='loaded'] {
         height: 49px;
         width: 49px;
-
     }
 
     main .section.back-to-top.active::before,
@@ -232,6 +263,21 @@ sup {
     main .section.back-to-top.active::after {
         width: 54px;
         height: 54px;
+    }
+
+    /* Content-band tablet styles */
+    .content-band.columns > div {
+        flex-direction: unset;
+        column-gap: var(--spacer-element-07);
+    }
+
+    .content-band.columns > div > div {
+        flex: 1;
+        margin-left: 0;
+    }
+
+    .content-band.columns > div > div:first-of-type {
+        margin-left: unset;
     }
 }
 
@@ -398,6 +444,11 @@ sup {
 
     main .article-content {
         padding-bottom: 160px;
+    }
+
+    /* Content-band desktop styles */
+    .content-band.icon-list h4 {
+        font-size: var(--font-size-21);
     }
 }
 
@@ -777,5 +828,4 @@ main .section.leadership-content .columns > div > div > h6 {
         margin-left: unset;
     }
 }
-
 


### PR DESCRIPTION
Initial styles to support the "icon list" use case.

Additional work required to support "image list" as described in the issue: 
https://github.com/hlxsites/merative/issues/99

Block:

![image](https://user-images.githubusercontent.com/1048207/219797778-c5cd8485-1c42-445f-a306-9ea064f3444c.png)

Fix #99 (partially)

Test URLs:
- Before: https://main--merative2--hlxsites.hlx.page/drafts/bruce/clinical-development
- After: https://issue-99-content-band-list--merative2--hlxsites.hlx.page/drafts/bruce/clinical-development
