### PR TITLE
ignore empty header tags

### DIFF
--- a/blocks/blog-left-nav/blog-left-nav.js
+++ b/blocks/blog-left-nav/blog-left-nav.js
@@ -82,7 +82,8 @@ export default function decorate(block) {
 
   const headerTags = articleContentWrapper.querySelectorAll('h1, h2, h3');
   headerTags.forEach((headerTag) => {
-    anchorTagLinkCreation(headerTag.getAttribute('id'), headerTag.textContent);
+    // Ignore heading tags with no content
+    if (headerTag.textContent) anchorTagLinkCreation(headerTag.getAttribute('id'), headerTag.textContent);
   });
 
   const socialLinks = ['linkedin', 'twitter', 'facebook', 'share'];


### PR DESCRIPTION
Before URL - see how left nav breaks with an empty H3 in the middle of the content.
After URL - see how that empty H3 is ignored and the left nav renders correctly.

Fix #112 

Test URLs:
- Before: https://main--merative2--hlxsites.hlx.page/drafts/amol/4-ways-rsna-laid-out-imaging-ai-future
- After: https://issue-112-blog-left-nav--merative2--hlxsites.hlx.page/drafts/amol/4-ways-rsna-laid-out-imaging-ai-future
