### PR TITLE
Added manual links to Teaser List

### DIFF
--- a/blocks/related-resources/related-resources.js
+++ b/blocks/related-resources/related-resources.js
@@ -42,7 +42,7 @@ async function setRowDetails(row, block) {
 export default async function decorate(block) {
   const pathnames = [...block.querySelectorAll('a')].map((a) => {
     const url = new URL(a.href);
-    if (window.location.hostname === url.hostname) return url.pathname;
+    if (url.hostname.endsWith('.page') || url.hostname.endsWith('.live') || url.hostname.endsWith('merative.com')) return url.pathname;
     return a.href;
   });
   const blockCopy = block.cloneNode(true);

--- a/blocks/teaser-list/teaser-list.js
+++ b/blocks/teaser-list/teaser-list.js
@@ -8,7 +8,7 @@ async function setRowDetails(row, block) {
     if ((a.href === row.path) || (pathname === row.path)) aElement = a;
   });
   if (aElement) {
-    row['teaser-link-text'] = aElement.innerText;
+    row['teaser-link-text'] = aElement.innerText.trim();
     // Go up one level since <a> is wrapped inside a <p> usually
     let el = aElement.parentElement;
     // Loop through previous elements until you hit an <a>

--- a/blocks/teaser-list/teaser-list.js
+++ b/blocks/teaser-list/teaser-list.js
@@ -1,5 +1,44 @@
 import { lookupPages } from '../../scripts/scripts.js';
 
+async function setRowDetails(row, block) {
+  // Get the right element for this row
+  let aElement = {};
+  [...block.querySelectorAll('a')].forEach((a) => {
+    const { pathname } = new URL(a.href);
+    if ((a.href === row.path) || (pathname === row.path)) aElement = a;
+  });
+  if (aElement) {
+    row['teaser-link-text'] = aElement.innerText;
+    // Go up one level since <a> is wrapped inside a <p> usually
+    let el = aElement.parentElement;
+    // Loop through previous elements until you hit an <a>
+    while (el) {
+      el = el.previousElementSibling;
+      // Break if you find an anchor link in the previous element
+      const childAnchor = el.querySelector('a');
+      if (childAnchor) {
+        break;
+      }
+      // set the row object properties based on the type of node we hit
+      switch (el.nodeName) {
+        case 'H1':
+        case 'H2':
+        case 'H3':
+        case 'H4':
+        case 'H5':
+        case 'H6':
+          row.title = el.innerHTML;
+          break;
+        case 'P':
+          row.description = el.innerHTML;
+          break;
+        default:
+          break;
+      }
+    }
+  }
+}
+
 function createCard(row, style) {
   const card = document.createElement('div');
   if (style) card.classList.add(style);
@@ -19,10 +58,13 @@ function createCard(row, style) {
 
 export default async function decorate(block) {
   const pathnames = [...block.querySelectorAll('a')].map((a) => new URL(a.href).pathname);
+  const blockCopy = block.cloneNode(true);
   block.textContent = '';
   const pageList = await lookupPages(pathnames);
   if (pageList.length) {
     pageList.forEach((row) => {
+      // If the URL was not in the index, it is curated. Let's get the content differently
+      if (row.title === undefined) setRowDetails(row, blockCopy);
       block.append(createCard(row, 'teaser-card'));
     });
   } else {

--- a/blocks/teaser-list/teaser-list.js
+++ b/blocks/teaser-list/teaser-list.js
@@ -57,7 +57,11 @@ function createCard(row, style) {
 }
 
 export default async function decorate(block) {
-  const pathnames = [...block.querySelectorAll('a')].map((a) => new URL(a.href).pathname);
+  const pathnames = [...block.querySelectorAll('a')].map((a) => {
+    const url = new URL(a.href);
+    if (url.hostname.endsWith('.page') || url.hostname.endsWith('.live') || url.hostname.endsWith('merative.com')) return url.pathname;
+    return a.href;
+  });
   const blockCopy = block.cloneNode(true);
   block.textContent = '';
   const pageList = await lookupPages(pathnames);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -225,7 +225,16 @@ export async function lookupPages(pathnames) {
       lookup,
     };
   }
-  const result = pathnames.map((path) => window.pageIndex.lookup[path]).filter((e) => e);
+
+  const result = pathnames.map((path) => {
+    // path is not in the index (external links)
+    if (window.pageIndex.lookup[path] === undefined) {
+      return {
+        path,
+      };
+    }
+    return window.pageIndex.lookup[path];
+  });
   return (result);
 }
 


### PR DESCRIPTION
Added the ability to have manual links and content in the Teaser List block

Fix #158 

Test URLs:
- Before: https://main--merative2--hlxsites.hlx.page/drafts/amol/teaser-list
- After: https://issue-158-teaser-list--merative2--hlxsites.hlx.page/drafts/amol/teaser-list
