### PR TITLE
limited leftnav and breadcrumb to only top main el

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -126,24 +126,26 @@ function buildPageDivider(main) {
 }
 
 // auto block build for blog left nav
-function buildBlogLeftNavBlock(main) {
+function buildBlogLeftNavBlock() {
   if (getMetadata('template') === 'Blog Article') {
+    const topMain = document.querySelector('body > main');
     const section = document.createElement('div');
     section.append(buildBlock('blog-left-nav', {
       elems: [],
     }));
-    main.prepend(section);
+    topMain.prepend(section);
   }
 }
 
 // auto block to create breadcrumb for blog articles
-function buildBlogBreadCrumbBlock(main) {
+function buildBlogBreadCrumbBlock() {
   if (getMetadata('template') === 'Blog Article') {
+    const topMain = document.querySelector('body > main');
     const section = document.createElement('div');
     section.append(buildBlock('blog-breadcrumb', {
       elems: [],
     }));
-    main.prepend(section);
+    topMain.prepend(section);
   }
 }
 
@@ -171,8 +173,8 @@ function buildDocumentUrl(main) {
 function buildAutoBlocks(main) {
   try {
     buildBackToTopBlock(main);
-    buildBlogLeftNavBlock(main);
-    buildBlogBreadCrumbBlock(main);
+    buildBlogLeftNavBlock();
+    buildBlogBreadCrumbBlock();
     buildDocumentUrl(main);
     buildTags(main);
     buildPageDivider(main);


### PR DESCRIPTION


## Issue

Fix #219

## Test URLs
  
- Before: https://main--merative2--hlxsites.hlx.page/blog/4-ways-rsna-laid-out-imaging-ai-future
- After: https://issue-219-blog-fragment-bug--merative2--hlxsites.hlx.page/blog/4-ways-rsna-laid-out-imaging-ai-future
  
## Description
Addition of a fragment that has another main element basically triggered the auto-blocking of another set of left nav and breadcrumb for blog pages.