### PR TITLE
Blog breadcrumb uses some default link styles #226

### DIFF
--- a/blocks/blog-breadcrumb/blog-breadcrumb.css
+++ b/blocks/blog-breadcrumb/blog-breadcrumb.css
@@ -18,7 +18,7 @@
     display: inline;
 }
 
-.breadcrumb-navigation > li > a {
+ul.breadcrumb-navigation > li > a:any-link {
     color: var(--neutral-carbon);
     text-decoration: none;
     font-family: var(--sans-serif-font-regular);
@@ -27,24 +27,28 @@
     font-size: var(--font-size-16);
     line-height: var(--line-height-160);
     letter-spacing: 0.01em;
+    border-bottom: none;
 }
 
-.breadcrumb-navigation > li > a:hover {
+ul.breadcrumb-navigation > li > a:any-link:hover,
+ul.breadcrumb-navigation > li > a:any-link:active {
     color: var(--primary-purple);
     text-decoration: underline;
+    -webkit-text-fill-color: unset;
 }
 
-.breadcrumb-navigation li::after {
-    padding: 0 10px 0 0;
+ul.breadcrumb-navigation > li > a::after {
     content: "";
-    background: url('../../icons/arrow-breadcrumb.svg') no-repeat;
-    top: 4px;
     position: relative;
+    top: 4px;
     margin: 0 16px 0 10px;
+    padding: 0 10px 0 0;
+    background: url('../../icons/arrow-breadcrumb.svg') no-repeat;
 }
 
-.breadcrumb-navigation li:hover::after {
-    color: var(--primary-purple);
+ul.breadcrumb-navigation > li > a:any-link:hover::after,
+ul.breadcrumb-navigation > li > a:any-link:active::after {
+    background: url('../../icons/arrow-breadcrumb-purple.svg') no-repeat;
 }
 
 @media only screen and (min-width: 768px){

--- a/icons/arrow-breadcrumb-purple.svg
+++ b/icons/arrow-breadcrumb-purple.svg
@@ -1,0 +1,3 @@
+<svg width="7" height="12" viewBox="0 0 7 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1L6 6L1 11" stroke="#9900FF" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after): -->

## Issue

Fix https://github.com/hlxsites/merative/issues/226

## Test URLs
  
- Before: https://main--merative--hlxsites.hlx.page/blog/merge-newsletter-march-2023
- After: https://issue-226-breadcrumb--merative--hlxsites.hlx.page/blog/merge-newsletter-march-2023
  
## Description

- override default link styles
- fix hover style of breadcrumb arrow