### PR TITLE
only show card if content from link is legit

### DIFF
--- a/blocks/related-resources/related-resources.js
+++ b/blocks/related-resources/related-resources.js
@@ -63,7 +63,7 @@ export default async function decorate(block) {
   if (pageList.length) {
     pageList.forEach((row) => {
       setRowDetails(row, blockCopy);
-      block.append(createDocumentCard(row, ['document-card']));
+      if (row.title && row.description) block.append(createDocumentCard(row, ['document-card']));
     });
     decorateButtons(block, { decorateClasses: false, excludeIcons: [] });
     decorateIcons(block);


### PR DESCRIPTION

## Issue

Fix #243

## Test URLs
  
- Before: https://main--merative2--hlxsites.hlx.page/drafts/amol/related-resources
- After: https://issue-243-related-resources-links--merative2--hlxsites.hlx.page/drafts/amol/related-resources
  
## Description
If title or description are not there, don't show the card at all.