### PR TITLE
removing the animation in level-two header

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -487,9 +487,10 @@ header nav .nav-sections > ul > li {
     color: var(--neutral-carbon);
     margin: 0;
     padding: 3% calc((100vw - var(--section-width-desktop)) / 2) var(--spacer-layout-07);
-    animation: fadeIn .25s;
+
+    /* animation: fadeIn .25s;
     animation-fill-mode: forwards;
-    transition: none;
+    transition: none; */
     z-index: 0;
   }
 


### PR DESCRIPTION

## Issue
Issue that Cedric saw in his chrome on mac where the animation fill forward was not working

## Test URLs
  
- Before: https://main--merative2--hlxsites.hlx.page/
- After: https://cedrics-weird-issue--merative2--hlxsites.hlx.page/
  
## Description
removed the animation on level-two of the header and sticking to simply showing it. The animation was not even visible properly since it was so fast.