### PR TITLE
exclude drafts path from sidekick publish

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -13,7 +13,7 @@
         },
         {
             "id": "publish",
-            "excludePaths": [ "**/drafts/**","sites/Merative.comWebsite/Shared%20Documents/Forms/AllItems.aspx?ga=1&id=%2Fsites%2FMerative%2EcomWebsite%2FShared%20Documents%2Fwebsite%2Fdrafts%2F" ]
+            "excludePaths": [ "**/drafts/**","**/Merative.comWebsite/Shared%20Documents/Forms/AllItems.aspx?ga=1&id=/sites/Merative.comWebsite/Shared%20Documents/website/drafts/**" ]
           }
     ]
 }

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -13,7 +13,7 @@
         },
         {
             "id": "publish",
-            "excludePaths": [ "**/drafts/**","**/sites/Merative.comWebsite/Shared%20Documents/website/drafts/**" ]
+            "excludePaths": [ "**/drafts/**","sites/Merative.comWebsite/Shared%20Documents/website/drafts/**" ]
           }
     ]
 }

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -13,7 +13,7 @@
         },
         {
             "id": "publish",
-            "excludePaths": [ "**/drafts/**","sites/Merative.comWebsite/Shared%20Documents/**" ]
+            "excludePaths": [ "**/drafts/**","**/sites/**" ]
           }
     ]
 }

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -13,7 +13,7 @@
         },
         {
             "id": "publish",
-            "excludePaths": [ "**/drafts/**","**/sites/**" ]
+            "excludePaths": [ "**/drafts/**" ]
           }
     ]
 }

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -13,7 +13,7 @@
         },
         {
             "id": "publish",
-            "excludePaths": [ "**/drafts/**" ]
+            "excludePaths": [ "**/drafts/**","sites/Merative.comWebsite/Shared%20Documents/Forms/AllItems.aspx?ga=1&id=%2Fsites%2FMerative%2EcomWebsite%2FShared%20Documents%2Fwebsite%2Fdrafts%2F" ]
           }
     ]
 }

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -13,7 +13,7 @@
         },
         {
             "id": "publish",
-            "excludePaths": [ "**/drafts/**","sites/Merative.comWebsite/Shared%20Documents/website/drafts/**" ]
+            "excludePaths": [ "**/drafts/**","sites/Merative.comWebsite/Shared%20Documents/**" ]
           }
     ]
 }

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,6 +1,5 @@
 {
     "project": "Merative",
-    "host": "www.merative.com",
     "plugins": [
         {
             "id": "library",

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -10,6 +10,10 @@
             "paletteRect": "top: auto; bottom: 20px; left: 20px; height: 398px; width: 360px;",
             "url": "/block-library/library",
             "includePaths": [ "**.docx**" ]
-        }
+        },
+        {
+            "id": "publish",
+            "excludePaths": [ "**/drafts/**" ]
+          }
     ]
 }

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -17,7 +17,7 @@
         },        
         {
             "id": "bulk-publish",
-            "excludePaths": [ "**/drafts/**" ]
+            "excludePaths": [ "**/Forms/**" ]
         }
     ]
 }

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,5 +1,6 @@
 {
     "project": "Merative",
+    "host": "www.merative.com",
     "plugins": [
         {
             "id": "library",
@@ -13,6 +14,10 @@
         {
             "id": "publish",
             "excludePaths": [ "**/drafts/**" ]
-          }
+        },        
+        {
+            "id": "bulk-publish",
+            "excludePaths": [ "**/drafts/**" ]
+        }
     ]
 }

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -14,10 +14,6 @@
         {
             "id": "publish",
             "excludePaths": [ "**/drafts/**" ]
-        },        
-        {
-            "id": "bulk-publish",
-            "excludePaths": [ "**/Forms/**" ]
         }
     ]
 }

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -13,7 +13,7 @@
         },
         {
             "id": "publish",
-            "excludePaths": [ "**/drafts/**","**/Merative.comWebsite/Shared%20Documents/Forms/AllItems.aspx?ga=1&id=/sites/Merative.comWebsite/Shared%20Documents/website/drafts/**" ]
+            "excludePaths": [ "**/drafts/**","**/sites/Merative.comWebsite/Shared%20Documents/website/drafts/**" ]
           }
     ]
 }


### PR DESCRIPTION
Added the config to exclude anything with /drafts/ from being published from the sidekick when viewing the .page link.

UPDATE: This PR only hides the publish button from the web page under /drafts for now. The addition of this feature to Sharepoint will be coming from the official Sidekick project, which I am getting some help with.

## Issue

Fix #189 

## Test URLs
  
- Before: https://main--merative2--hlxsites.hlx.page/drafts/chelms/company
- After: https://189-sidekick--merative2--hlxsites.hlx.page/drafts/chelms/company
  
## Description
To test, you need to temporarily edit the Merative project's github URL in your sidekick
![image](https://github.com/hlxsites/merative2/assets/3883795/67fb9056-4099-4737-9cc2-a8f5143d569d)

Then go to the "after" URL and you will see there is no "Publish" button available.
![image](https://github.com/hlxsites/merative2/assets/3883795/209dd2b0-0fad-4b99-a3da-bb64beb40a22)

