### PR TITLE
better rendering of local links in solutions-list of nav

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -723,6 +723,7 @@ header nav .nav-sections > ul > li {
     text-decoration: none;
     border-bottom: 1px solid var(--neutral-sand);
     margin: var(--spacer-element-05) 0;
+    color: currentcolor;
   }
 
   header nav .nav-sections > ul > li[aria-expanded='true'] .mega-menu-content .columns.solution-list > div > div > a:last-child  {

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -115,8 +115,7 @@ export default async function decorate(block) {
   block.textContent = '';
 
   // fetch nav content
-  // const navPath = cfg.nav || '/nav';
-  const navPath = cfg.nav || '/drafts/chelms/nav'; // temporary for testing
+  const navPath = cfg.nav || '/nav';
   const resp = await fetch(`${navPath}.plain.html`);
   if (!resp.ok) {
     return;

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -115,7 +115,8 @@ export default async function decorate(block) {
   block.textContent = '';
 
   // fetch nav content
-  const navPath = cfg.nav || '/drafts/chelms/nav';
+  // const navPath = cfg.nav || '/nav';
+  const navPath = cfg.nav || '/drafts/chelms/nav'; // temporary for testing
   const resp = await fetch(`${navPath}.plain.html`);
   if (!resp.ok) {
     return;

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -59,7 +59,7 @@ function buildMegaMenu(navItem) {
   if (!navItem) {
     return;
   }
-  const menuLinks = navItem.querySelectorAll('.columns.solution-list p > a:not(.button)');
+  const menuLinks = navItem.querySelectorAll('.columns.solution-list p > a');
   [...menuLinks].forEach((link) => {
     const cell = link.closest('div');
     const linkParent = link.parentElement;
@@ -115,7 +115,7 @@ export default async function decorate(block) {
   block.textContent = '';
 
   // fetch nav content
-  const navPath = cfg.nav || '/nav';
+  const navPath = cfg.nav || '/drafts/chelms/nav';
   const resp = await fetch(`${navPath}.plain.html`);
   if (!resp.ok) {
     return;


### PR DESCRIPTION
Since there are no button styles in the solutions-list design of the mega nav, this change will allow environmental-relative links without breaking the style.

Fix #188 

## Test URLs
  
- Before: https://main--merative2--hlxsites.hlx.page
- After: https://188-nav--merative2--hlxsites.hlx.page
  
## To test:
Don't merge this as-is!
- I temporarily set the path to the Nav for testing purposes and will change this back before merging.
- Going to https://188-nav--merative2--hlxsites.hlx.page and click "Solutions1" in meganav header
- Now click on "Enterprise Imaging" in the subnav (which is pointing to a test fragment)
- All 3 links shown in the meganav for "Enterprise Imaging" should have the same expected style.
After this change is approved, I will revert the nav path before merging.

