### PR TITLE
Sharepoint hide pub button in drafts

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -12,6 +12,10 @@
             "includePaths": [ "**.docx**" ]
         },
         {
+            "id": "bulk-publish",
+            "excludePaths": [ "**%2Fdrafts**" ]
+          },
+        {
             "id": "publish",
             "excludePaths": [ "**/drafts/**" ]
         }

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -12,12 +12,8 @@
             "includePaths": [ "**.docx**" ]
         },
         {
-            "id": "bulk-publish",
-            "excludePaths": [ "**%2Fdrafts**" ]
-          },
-        {
             "id": "publish",
-            "excludePaths": [ "**/drafts/**" ]
+            "excludePaths": [ "**/drafts/**","**%2Fdrafts**" ]
         }
     ]
 }


### PR DESCRIPTION
This is a PR for hiding the publish button on Sharepoint at the drafts directory and below.
NOTE: Browser caching inconsistencies seems to be remediated with my last commit.

## Issue

Fix #189 

## Test URLs
  
- Before: https://main--merative2--hlxsites.hlx.page/
- After: https://189-sharepoint--merative2--hlxsites.hlx.page/
  
## To test
You need to update your sidekick to the latest release. https://github.com/adobe/helix-sidekick-extension/releases/tag/v6.19.1 (if it didn't update automatically).
Like before, your sidekick tree path needs to be temporarily changed to /189-sharepoint to test.
