### PR TITLE
change footer code for h3

### DIFF
--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -28,7 +28,7 @@ footer .footer-links > div > div:last-of-type {
     flex: 1 1 6.825rem;
 }
 
-footer .footer-links > div > div > h4 {
+footer .footer-links > div > div > h3 {
     color: var(--neutral-grey-tint120);
     font-size: var(--font-size-18);
     font-family: var(--sans-serif-font-medium);
@@ -233,7 +233,7 @@ footer div:last-of-type > ul:last-of-type > li:last-of-type a:hover {
         height: 75px;
     }
 
-    footer .footer-links > div > div > h4 {
+    footer .footer-links > div > div > h3 {
         margin: 0 0 32px;
     }
 
@@ -336,7 +336,7 @@ footer div:last-of-type > ul:last-of-type > li:last-of-type a:hover {
         height: 0;
     }
 
-    footer .footer-links > div > div > h4 {
+    footer .footer-links > div > div > h3 {
         color: var(--neutral-white);
         font-size: var(--font-size-18);
         font-family: var(--sans-serif-font-semibold);

--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -41,9 +41,9 @@ function addContactLink(e) {
 }
 
 function addCSSToLinkHeadings(block) {
-  const h4elements = block.querySelectorAll('.footer-links > div > div > h4');
-  h4elements.forEach((h4element) => {
-    h4element.classList.add('link-section-heading');
+  const h3elements = block.querySelectorAll('.footer-links > div > div > h3');
+  h3elements.forEach((h3element) => {
+    h3element.classList.add('link-section-heading');
   });
 }
 
@@ -62,8 +62,7 @@ function buildMobileFooter(block) {
 export default async function decorate(block) {
   const cfg = readBlockConfig(block);
   block.textContent = '';
-
-  const footerPath = cfg.footer || '/footer';
+  const footerPath = cfg.footer || '/drafts/chelms/footer'; // temporary change for testing
   const resp = await fetch(`${footerPath}.plain.html`);
   const html = await resp.text();
   const footer = document.createElement('div');


### PR DESCRIPTION
Don't merge as-is! 
Footer path was temporarily changed for testing purposes. 

## Issue

Fix #203 

## Test URLs
  
- Before: https://main--merative2--hlxsites.hlx.page/
- After: https://203-SEOfooter--merative2--hlxsites.hlx.page/
  
## Testing and next steps
- Inspect element of the footer for 203-SEOfooter branch, headings are now H3
- Compare styles for desktop and mobile against the main branch, which has H4s -- they should match.
- See that the ligthouse SEO score no longer includes an alert for footer headings https://pagespeed.web.dev/analysis/https-203-seofooter--merative2--hlxsites-hlx-page/qd2o5nm3qy?form_factor=desktop
- After review, I will change the path back to /footer, and merge into main branch.
- The live footer.docx will be authored to have H3 headers in place of H4 and published.


