### PR TITLE
Teaser-list now outputs h3

### DIFF
--- a/blocks/teaser-list/teaser-list.css
+++ b/blocks/teaser-list/teaser-list.css
@@ -48,10 +48,13 @@
   min-height: 727px;
 }
 
-.teaser-list h6 {
+.teaser-list h3 {
+  font-family: var(--sans-serif-font-light);
   font-size: var(--font-size-18);
+  font-weight: 700;
   line-height: 160%;
   letter-spacing: .16px;
+  margin: 0;
 }
 
 .teaser-list .teaser-card .teaser-link {
@@ -134,7 +137,7 @@
     grid-template-rows: auto auto auto;
   }
 
-  .teaser-list .teaser-card h6 {
+  .teaser-list .teaser-card h3 {
     font-size: var(--font-size-21);
   }
 

--- a/blocks/teaser-list/teaser-list.js
+++ b/blocks/teaser-list/teaser-list.js
@@ -62,7 +62,7 @@ function createCard(row, style) {
   } else {
     link.innerText = 'Learn more about';
   }
-  if (row.title) card.innerHTML += `<h6>${row.title}</h6>`;
+  if (row.title) card.innerHTML += `<h3>${row.title}</h3>`;
   if (row.description) card.innerHTML += `<p>${row.description}</p>`;
   card.append(link);
   return (card);


### PR DESCRIPTION
Teaser list now outputs H3 headings instead of H6 to fix Lighthouse accessibility complaints at 
https://pagespeed.web.dev/analysis/https-205-seoteaserlist--merative2--hlxsites-hlx-page/4ecu1r5bn1?form_factor=mobile

## Issue

Fix #205

## Test URLs
  
- Before: https://main--merative2--hlxsites.hlx.page/
- After: https://205-seoteaserlist-merative2--hlxsites.hlx.page/
  
## Description
Compare the H3 headings for desktop, tablet, and mobile in the "WHAT WE DO" section against the Main branch H6 headings; styles should match.

Teaser list content will not need to be reauthored.