### PR TITLE
Add h3 to .columns.icon-list styles

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -719,12 +719,6 @@ main .columns > div > div > h4:first-child {
     padding-bottom: var(--spacer-layout-06);
   }
 
-  .section.teaser-list-manual {
-    width: var(--section-width-desktop);
-    gap: 140px;
-    padding: var(--spacer-layout-07) 0;
-  }
-
   .section.promo .columns .button-container {
     margin-top: var(--spacer-layout-04);
   }


### PR DESCRIPTION
My test page was reauthored, as will need to be done for the other events pages. I will not merge this code until I have reauthored all the events pages as needed first. Then upon merge, I will immediately publish the reauthored event pages the way I did my test page below.

## Issue

Fix #207 

## Test URLs
  
- Before: https://main--merative2--hlxsites.hlx.page/events/2023-zelta-user-conference
- After: https://207-seocolumns--merative2--hlxsites.hlx.page/drafts/chelms/2023-zelta-user-conference
  
## Description
The two test URLs should have matching styles, despite my draft page having H3 for the "EVENT SPECIFICS" section vs. the live page having H4 headings.

