### PR TITLE
fix(blog pages): accessibility, tags

### DIFF
--- a/blocks/author-bio/author-bio.css
+++ b/blocks/author-bio/author-bio.css
@@ -9,8 +9,8 @@ main .author-bio {
     flex-wrap: wrap;
     align-items: center;
     color: var(--neutral-carbon);
+    margin-bottom: 32px;
 }
-
 
 main .author-bio img.author-img{
     width: 48px;
@@ -20,12 +20,15 @@ main .author-bio img.author-img{
 }
 
 @media only screen and (min-width: 1200px) {
+    main .author-bio {
+      margin-bottom: 48px;
+    }
+
     main .author-bio img.author-img {
         width: 64px;
         height: 64px;
     }
 }
-
 
 main .author-bio .author-name {
     margin-left: 16px;

--- a/blocks/blog-left-nav/blog-left-nav.css
+++ b/blocks/blog-left-nav/blog-left-nav.css
@@ -146,11 +146,6 @@ html {
         display: flex;
     }
 
-    .article-content-wrapper h1 {
-        font-size: var(--font-size-45);
-        margin-top: 0;
-        }
-
     .section.article-content .article-main-wrapper .blog-left-nav {
         width: 240px;
         margin: 48px 48px 0 0;
@@ -233,6 +228,7 @@ html {
         padding-top: 24px;
         padding-bottom: 24px !important;
     } */
+
     .article-main-wrapper {
         display: flex;
         flex-direction: column-reverse;
@@ -258,7 +254,6 @@ html {
     }
 
 }
-
 
 /* devices */
 
@@ -300,7 +295,6 @@ html {
     }
 
 }
-
 
 /* mobile devices */
 

--- a/blocks/teaser-list/teaser-list.css
+++ b/blocks/teaser-list/teaser-list.css
@@ -49,9 +49,8 @@
 }
 
 .teaser-list h3 {
-  font-family: var(--sans-serif-font-light);
+  font-family: var(--sans-serif-font-medium);
   font-size: var(--font-size-18);
-  font-weight: 700;
   line-height: 160%;
   letter-spacing: .16px;
   margin: 0;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -93,11 +93,19 @@ function buildTags(main) {
   tagsElement.classList.add('tags');
   if (category) {
     tagsElement.append(buildBlock('tags', { elems: [] }));
-    const firstH2 = main.querySelector('h2:first-of-type');
-    const p = main.querySelector('p:first-of-type');
+    // if there's a lede before the picture
+    const firstH1 = main.querySelector('h1:first-of-type');
+    const firstP = main.querySelector('p:first-of-type:not(.only-picture)');
+    if (firstH1 && firstP
+      // eslint-disable-next-line no-bitwise
+      && (firstH1.compareDocumentPosition(firstP) & Node.DOCUMENT_POSITION_FOLLOWING)) {
+      firstP.classList.add('lede');
+    }
+    const pic = main.querySelector('.only-picture');
+    const bio = main.querySelector('.author-bio');
     // eslint-disable-next-line no-bitwise
-    if (firstH2 && p && (firstH2.compareDocumentPosition(p) & Node.DOCUMENT_POSITION_FOLLOWING)) {
-      firstH2.after(tagsElement);
+    if (pic && bio && (pic.compareDocumentPosition(bio) & Node.DOCUMENT_POSITION_FOLLOWING)) {
+      pic.before(tagsElement);
     }
   }
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -94,11 +94,10 @@ function buildTags(main) {
   if (category) {
     tagsElement.append(buildBlock('tags', { elems: [] }));
     const firstH2 = main.querySelector('h2:first-of-type');
-    const image = main.querySelector('p.only-picture');
-    const comparePosition = firstH2.compareDocumentPosition(image);
+    const p = main.querySelector('p:first-of-type');
     // eslint-disable-next-line no-bitwise
-    if (firstH2 && image && (comparePosition & Node.DOCUMENT_POSITION_FOLLOWING)) {
-      image.before(tagsElement);
+    if (firstH2 && p && (firstH2.compareDocumentPosition(p) & Node.DOCUMENT_POSITION_FOLLOWING)) {
+      firstH2.after(tagsElement);
     }
   }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -196,6 +196,7 @@
   --section-width-mobile: 328px;
   --section-width-tablet-small: 696px;
   --section-width-tablet-large: 928px;
+  --text-max-container: 648px;
 }
 
 html {
@@ -346,6 +347,16 @@ blockquote {
   margin: var(--spacer-element-05) 0 var(--spacer-element-05);
 }
 
+.article-content-wrapper h1 {
+font-size: var(--font-size-32);
+margin: 16px 0;
+}
+
+p.lede {
+  font-size: var(--font-size-18);
+  max-width: var(--text-max-container);
+}
+
 .no-pad.section,
 .no-pad.section .default-content-wrapper,
 .no-pad.section p {
@@ -454,10 +465,6 @@ main .section > div:last-child {
 
 .section.article-content .article-main-wrapper {
   padding-top: var(--spacer-element-05);
-}
-
-.article-content-wrapper h2:first-of-type {
-  margin: unset;
 }
 
 .columns.row-header div > div > h2,
@@ -612,6 +619,11 @@ main .list-section ul li {
 
 .article-content-wrapper ul {
   margin-left: 25px;
+}
+
+.article-content-wrapper h2 {
+  font-size: var(--font-size-28);
+  margin: 24px 0;
 }
 
 /* stylelint-disable property-no-vendor-prefix */
@@ -931,7 +943,7 @@ main pre {
 .tags[data-block-status="loaded"] {
   display: flex;
   flex-wrap: wrap;
-  margin-top: var(--spacer-layout-03);
+  margin-top: var(--spacer-layout-01);
   margin-bottom: var(--spacer-layout-03);
 }
 
@@ -1459,6 +1471,21 @@ main pre {
     margin: var(--spacer-layout-07) 0;
   }
 
+  p.lede {
+    font-size: var(--font-size-24);
+  }
+
+  .article-content-wrapper h1 {
+    font-size: var(--font-size-45);
+    margin-top: 0;
+    margin-bottom: 16px;
+  }
+
+  .article-content-wrapper h2 {
+    font-size: var(--font-size-32);
+    margin: 48px 0;
+  }
+
   .article-content {
     padding-bottom: 160px;
   }
@@ -1466,6 +1493,11 @@ main pre {
   .article-content picture img {
     max-width: 744px;
   }
+
+  /* blog article */
+.tags[data-block-status="loaded"] {
+  margin-top: var(--spacer-layout-03);
+}
 
   .section.article-content .article-main-wrapper {
     padding-top: 0;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -196,9 +196,6 @@
   --section-width-mobile: 328px;
   --section-width-tablet-small: 696px;
   --section-width-tablet-large: 928px;
-
-  /* text max contianer */
-  --text-max-container: 648px;
 }
 
 html {
@@ -460,14 +457,7 @@ main .section > div:last-child {
 }
 
 .article-content-wrapper h2:first-of-type {
-  max-width: var(--text-max-container);
   margin: unset;
-}
-
-/* Article subhead */
-.article-content-wrapper h2:first-of-type + p {
-  font-size: var(--font-size-18);
-  max-width: var(--text-max-container);
 }
 
 .columns.row-header div > div > h2,
@@ -1434,11 +1424,6 @@ main pre {
     font-weight: var(--font-weight-light);
     line-height: var(--line-height-160);
     letter-spacing: var(--letter-spacing-1);
-  }
-
-  /* Article subhead */
-  .article-content-wrapper h2:first-of-type + p {
-    font-size: var(--font-size-24);
   }
 
   main {


### PR DESCRIPTION
This fixes styling for the subheading in ticket #172 .
It also has CSS fixes to allow for all the H1 + H2 changes I have made to the blog changes in order to increase accessibility score.

Also this puts tags ABOVE picture + author-bio, instead of BELOW the H1, since we may or may not have that lede paragraph.

Also has a quick fix for teaser-list font bug I introduced...

## Issue

Fix #210 

## Test URLs
  
- Before: https://main--merative2--hlxsites.hlx.page/blog/test-article-1
- After: https://210-seoblogs--merative2--hlxsites.hlx.page/blog/test-article-1
- Before: https://main--merative2--hlxsites.hlx.page/blog/human-centered-design-solves-business-problems
- After: https://210-seoblogs--merative2--hlxsites.hlx.page/blog/human-centered-design-solves-business-problems
  
## Description
CSS was added as seen via https://www.figma.com/file/5N1U4VkQfWxw72KLGFwHcj/Blog-article-additions?type=design&node-id=3-167&t=D5KcIKRLZmhFFsdM-0 .