### PR TITLE
fix(buildTags): lede class only added to 1st P before the picture now

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -96,13 +96,13 @@ function buildTags(main) {
     // if there's a lede before the picture
     const firstH1 = main.querySelector('h1:first-of-type');
     const firstP = main.querySelector('p:first-of-type:not(.only-picture)');
-    if (firstH1 && firstP
-      // eslint-disable-next-line no-bitwise
-      && (firstH1.compareDocumentPosition(firstP) & Node.DOCUMENT_POSITION_FOLLOWING)) {
-      firstP.classList.add('lede');
-    }
     const pic = main.querySelector('.only-picture');
     const bio = main.querySelector('.author-bio');
+    if (firstP && pic
+      // eslint-disable-next-line no-bitwise
+      && (firstP.compareDocumentPosition(pic) & Node.DOCUMENT_POSITION_FOLLOWING)) {
+      firstP.classList.add('lede');
+    }
     // eslint-disable-next-line no-bitwise
     if (pic && bio && (pic.compareDocumentPosition(bio) & Node.DOCUMENT_POSITION_FOLLOWING)) {
       pic.before(tagsElement);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -94,15 +94,14 @@ function buildTags(main) {
   if (category) {
     tagsElement.append(buildBlock('tags', { elems: [] }));
     // if there's a lede before the picture
-    const firstH1 = main.querySelector('h1:first-of-type');
     const firstP = main.querySelector('p:first-of-type:not(.only-picture)');
     const pic = main.querySelector('.only-picture');
-    const bio = main.querySelector('.author-bio');
     if (firstP && pic
       // eslint-disable-next-line no-bitwise
       && (firstP.compareDocumentPosition(pic) & Node.DOCUMENT_POSITION_FOLLOWING)) {
       firstP.classList.add('lede');
     }
+    const bio = main.querySelector('.author-bio');
     // eslint-disable-next-line no-bitwise
     if (pic && bio && (pic.compareDocumentPosition(bio) & Node.DOCUMENT_POSITION_FOLLOWING)) {
       pic.before(tagsElement);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -349,10 +349,11 @@ blockquote {
 
 .article-content-wrapper h1 {
 font-size: var(--font-size-32);
+max-width: var(--text-max-container);
 margin: 16px 0;
 }
 
-p.lede {
+.article-content-wrapper p.lede {
   font-size: var(--font-size-18);
   max-width: var(--text-max-container);
 }
@@ -863,6 +864,7 @@ main ul a:not(.button):active {
 }
 
 .article-content-wrapper {
+  max-width: 744px;
   font-weight: 300;
   font-size: 21px;
   line-height: 160%;
@@ -1488,10 +1490,6 @@ main pre {
 
   .article-content {
     padding-bottom: 160px;
-  }
-
-  .article-content picture img {
-    max-width: 744px;
   }
 
   /* blog article */


### PR DESCRIPTION
Now class="lede" is only added to the 1st P where the 1st P is not the image. If an article doesn't have a lede authored, no class="lede" is added anywhere.
Also added the necessary width to the H1 and the article-content body area as seen in https://www.figma.com/file/FSqQ1LYrVSssEFOZuOnMIE/Final-page-layouts-for-Merative.com?type=design&node-id=202%3A67585&t=7Hw8jMICddYr1S4k-1

## Issue 

Fix #214 

## Test URLs
  
- Before: https://main--merative2--hlxsites.hlx.page/blog/test-article
- After: https://214-lede--merative2--hlxsites.hlx.page/blog/test-article
- Before: https://main--merative2--hlxsites.hlx.page/blog/introducing-zelta
- After: https://214-lede--merative2--hlxsites.hlx.page/blog/introducing-zelta
  
## Description
Second test URL has no lede paragraph so there should be no lede class on the page.
