### PR TITLE
fix(blog-detail): adjust breadcrumb check & display to sentence case

### DIFF
--- a/blocks/blog-breadcrumb/blog-breadcrumb.js
+++ b/blocks/blog-breadcrumb/blog-breadcrumb.js
@@ -48,10 +48,16 @@ export default async function decorate(block) {
   const categoryName = getMetadata('category');
   const categoryBlogPages = await getBlogCategoryPages();
   categoryBlogPages.forEach((row) => {
-    // Check if the path is not '0' and the title matches the categoryName (case-insensitive)
+    // Check if the path is not '0' and the title matches the category name (case-insensitive)
     if ((row.path !== '0') && (row.title.toLowerCase() === categoryName.toLowerCase())) {
-      // Append a link element to liCategory with the path and categoryName (in sentence case)
-      liCategory.append(createLink(row.path, toSentenceCase(categoryName), toSentenceCase(categoryName)));
+      // Append a link element with the path & category name (in sentence case)
+      liCategory.append(
+        createLink(
+          row.path,
+          toSentenceCase(categoryName),
+          toSentenceCase(categoryName),
+        ),
+      );
     }
   });
   ul.append(liHome);

--- a/blocks/blog-breadcrumb/blog-breadcrumb.js
+++ b/blocks/blog-breadcrumb/blog-breadcrumb.js
@@ -37,14 +37,21 @@ export default async function decorate(block) {
     liHome.append(createLink('/blog', '...', 'Merative Blog'));
   }
 
+  // Return parameter in sentence case
+  function toSentenceCase(str) {
+    return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+  }
+
   // Create Category link
   const liCategory = document.createElement('li');
   liCategory.classList.add('category');
   const categoryName = getMetadata('category');
   const categoryBlogPages = await getBlogCategoryPages();
   categoryBlogPages.forEach((row) => {
-    if ((row.path !== '0') && (row.title === categoryName)) {
-      liCategory.append(createLink(row.path, categoryName, categoryName));
+    // Check if the path is not '0' and the title matches the categoryName (case-insensitive)
+    if ((row.path !== '0') && (row.title.toLowerCase() === categoryName.toLowerCase())) {
+      // Append a link element to liCategory with the path and categoryName (in sentence case)
+      liCategory.append(createLink(row.path, toSentenceCase(categoryName), toSentenceCase(categoryName)));
     }
   });
   ul.append(liHome);


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) or JIRA ticket your PR is for, as well as test URLs where your change can be observed (before and after): -->

<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes https://github.com/hlxsites/merative2/issues/245

## Description

**Changed**

- This PR fixes the breadcrumb display issue where the category title is not rendering because the value entered in the Sharepoint doc is `uppercase` where the category page is now set to `sentence case`.


## Design Specs


- Figma Link - N/A

## Test URLs
  
![Screen Shot 2023-06-20 at 3 12 28 PM](https://github.com/hlxsites/merative2/assets/1815714/07c167ff-0ea5-492d-a7dd-d19ca664cf6c)

- Before (Changes from `main`): https://main--merative2--hlxsites.hlx.live/blog/healthcare-analytics-dte-energy
- After (Changes from this PR): https://fix-blog-breadcrum-case-issue--merative2--proeung.hlx.page/blog/healthcare-analytics-dte-energy
  
## Testing Instruction

- Visit one of the blog pages (eg. https://fix-blog-breadcrum-case-issue--merative2--proeung.hlx.page/blog/healthcare-analytics-dte-energy)
- Ensure that the category name is displaying correctly in the breadcrumb