### PR TITLE
fix image aspect-ratio: author bio and blog.

### DIFF
--- a/blocks/author-bio/author-bio.css
+++ b/blocks/author-bio/author-bio.css
@@ -17,6 +17,7 @@ main .author-bio img.author-img{
     border-radius: 50%;
     height: 48px;
     border: 1px solid var(--neutral-sand);
+    object-fit: cover;
 }
 
 @media only screen and (min-width: 1200px) {
@@ -27,6 +28,7 @@ main .author-bio img.author-img{
     main .author-bio img.author-img {
         width: 64px;
         height: 64px;
+        object-fit: cover;
     }
 }
 

--- a/blocks/blog-home/blog-home.css
+++ b/blocks/blog-home/blog-home.css
@@ -118,6 +118,7 @@ main .section {
 .blog-home .blog-content  .blog-cards .blog-card .card-image {
     width: 328px;
     height: 219px;
+    object-fit: cover;
 }
 
 .blog-home .blog-content  .blog-cards .blog-card.featured-article .card-image img,
@@ -520,6 +521,7 @@ main .section {
     .blog-home .blog-content  .blog-cards .blog-card .card-image img {
         width: 336px;
         height: 224px;
+        object-fit: cover;
     }
 
     .blog-home > .blog-content > .blog-cards > .blog-card > .card-content a {
@@ -727,6 +729,7 @@ main .section {
     .blog-home .blog-content  .blog-cards .blog-card .card-image img {
         width: 396px;
         height: 264px;
+        object-fit: cover;
     }
 
     .blog-home .blog-content  .blog-cards .blog-card.featured-article .card-image,


### PR DESCRIPTION
## Issue

Fixes #153 

Description

Correct (Lighthouse best practices) image aspect-ratio for related article card images.

For Testing:
- On browser visit the following URLs (i.e., Chrome).
Before:

https://main--merative2--hlxsites.hlx.page/blog
https://main--merative2--hlxsites.hlx.page/blog/test-article

After:

https://153-incorrect-aspect-ratio--merative2--hlxsites.hlx.page/blog
https://153-incorrect-aspect-ratio--merative2--hlxsites.hlx.page/blog/test-article

- Then, go to developer tool -> Lighthouse -> analysis page load
- In Lighthouse report, go to best practices and observe that there is no failure in displays images with incorrect aspect.
