### PR TITLE
fix(hotjar): add hotjar data-hj-allow-iframe attribute to iframes & add missing wss://*.hotjar.com in CSP

### DIFF
--- a/blocks/pdf-viewer/pdf-viewer.js
+++ b/blocks/pdf-viewer/pdf-viewer.js
@@ -63,6 +63,12 @@ const embedPDFViewer = (
             showBookmarks,
             showThumbnails,
           });
+
+          // Add data-hj-allow-iframe attribute to the generated iframe
+          const iframe = document.querySelector(`#${divId} iframe`);
+          if (iframe) {
+            iframe.setAttribute('data-hj-allow-iframe', '');
+          }
         }
       });
     }

--- a/blocks/video/video.js
+++ b/blocks/video/video.js
@@ -117,13 +117,13 @@ const loadYouTubePlayer = (element, videoId) => {
   // Create a new iframe element
   const iframe = document.createElement('iframe');
   iframe.src = `https://www.youtube.com/embed/${videoId}`;
-  
+
   // Add the data-hj-allow-iframe attribute
   iframe.setAttribute('data-hj-allow-iframe', '');
 
   // Append the iframe to the specified element
   element.appendChild(iframe);
-  
+
   // we have to create a new YT Player but then need to wait for its onReady event
   // before assigning it to the player map
   // eslint-disable-next-line no-new

--- a/blocks/video/video.js
+++ b/blocks/video/video.js
@@ -113,11 +113,21 @@ const loadYouTubePlayer = (element, videoId) => {
   const onPlayerReady = (event) => {
     playerMap[videoId] = event.target;
   };
+
+  // Create a new iframe element
+  const iframe = document.createElement('iframe');
+  iframe.src = `https://www.youtube.com/embed/${videoId}`;
+  
+  // Add the data-hj-allow-iframe attribute
+  iframe.setAttribute('data-hj-allow-iframe', '');
+
+  // Append the iframe to the specified element
+  element.appendChild(iframe);
+  
   // we have to create a new YT Player but then need to wait for its onReady event
   // before assigning it to the player map
   // eslint-disable-next-line no-new
-  new window.YT.Player(element, {
-    videoId,
+  new window.YT.Player(iframe, {
     events: {
       onReady: onPlayerReady,
     },

--- a/scripts/csp.json
+++ b/scripts/csp.json
@@ -55,7 +55,8 @@
       "*.medallia.com",
       "*.kampyle.com",
       "https://*.hotjar.com",
-      "https://*.hotjar.io"
+      "https://*.hotjar.io",
+      "wss://*.hotjar.com"
   ],
   "img-src": [
     "'self'",


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) or JIRA ticket your PR is for, as well as test URLs where your change can be observed (before and after): -->

<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes https://jira.wh-sdlc.watson-health.ibm.com/browse/MERATIVE-769

## Description

**Changed**

- This PR adds the `data-hj-allow-iframe` attribute to the `<iframe>` embeds that are used within the site (eg. PDF Viewer, YouTube Embed).
- This is needed because the default Hotjar solution natively blocks iFrame from screen recordings and heatmaps - this does not allow us to fully analyze certain asset types. See solution doc - https://help.hotjar.com/hc/en-us/articles/115011624347
- Add missing `wss://*.hotjar.com` to the CSP.json that got removed - https://github.com/hlxsites/merative2/pull/253/files


## Design Specs

- N/A - no impact to page design

## Test URLs
  
- Before (Changes from `main`): https://main--merative2--hlxsites.hlx.page/documents/ebook/achieving-the-benefits-of-ai
- After (Changes from this PR): https://fix-hotjar-iframe-attribute--merative2--proeung.hlx.page/documents/ebook/achieving-the-benefits-of-ai
  
## Testing Instruction

![Screen Shot 2023-06-27 at 4 25 41 PM](https://github.com/hlxsites/merative2/assets/1815714/597285af-ae4a-4ab4-a22c-90d8f11479aa)


- Inspect a PDF Viewer/Case Study page (eg. https://fix-hotjar-iframe-attribute--merative2--proeung.hlx.page/documents/ebook/achieving-the-benefits-of-ai).
- Ensure that the `data-hj-allow-iframe` attribute is added to the iframe code (eg. `<iframe data-hj-allow-iframe=""></iframe>`)
- Inspect a page with a video player (eg. https://fix-hotjar-iframe-attribute--merative2--proeung.hlx.page/drafts/putra/test-blog-detail-page).
- Ensure that the `data-hj-allow-iframe` attribute is added to the iframe code (eg. `<iframe data-hj-allow-iframe=""></iframe>`)