### PR TITLE
fix: background color less specificity

### DIFF
--- a/blocks/cta/cta.css
+++ b/blocks/cta/cta.css
@@ -4,7 +4,7 @@
     display: block;
 }
 
-.section.cta-container {
+.cta-container {
     background-color: var(--neutral-sand);
     margin: unset;
     min-height: 291px;


### PR DESCRIPTION


## Issue

Fixes #267 

## Description

> Add a human-readable description/detailed summary of what the PR is changing and any details about how and why. If applicable, include a screenshot indicating an example or examples of what the PR is changing in the application.

**New**

- <!-- {{ new thing }} -->

**Changed**

.cta-container class is less specific with the default neutral-beige color, allowing section metadata color choice to override.

## Design Specs

> If applicable, add the direct link to the design specs of the component/feature that's part of this PR.

[- Figma Link -](https://www.figma.com/file/vw24IPXXt4vCh9BNumka9A/Web--Merative-Digital-Design-System-2.0?type=design&node-id=1402-12379&mode=design&t=CkB81npPe1fiobQd-0)

## Test URLs
  
- Before (Changes from `main`): https://main--merative2--hlxsites.hlx.page/drafts/chelms/2023-zelta-user-conference
- After (Changes from this PR): https://267-ctabg--merative2--hlxsites.hlx.page/drafts/chelms/2023-zelta-user-conference
  
## Testing Instruction

See the 2 CTA sections on my draft page to compare.
- 
