### PR TITLE
fix(carousel): specifity of carousel bg color

### DIFF
--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -1,7 +1,7 @@
 /* Carousel block styles */
 
 /** Carousel section styling */
-.section.carousel-container {
+.carousel-container {
     background: var(--neutral-bone);
     padding: var(--spacer-layout-06) 0 var(--spacer-layout-06);
 }


### PR DESCRIPTION

## Issue

Fixes #263 

## Description

**Changed**

Specificity of the default background color was changed to allow for section metadata style to be authored.

## Design Specs

I don't have a design spec for the image-carousel-full-width carousel variation, it was created earlier in the year. I am just fixing the background color.

## Test URLs
  
- Before (Changes from `main`): https://main--merative2--hlxsites.hlx.page/drafts/chelms/2023-zelta-user-conference
- After (Changes from this PR): https://263-carouselbg--merative2--hlxsites.hlx.page/drafts/chelms/2023-zelta-user-conference
  
## Testing Instruction
This example shows the "image carousel full width" variation.
Please note that you won't visually see the carousel in the "before" link because it is white-on-white, but it is black on the "after" link.

- 
