### PR TITLE
chore(csp): add Adobe Target Script and Salesloft Script

### DIFF
--- a/scripts/csp.json
+++ b/scripts/csp.json
@@ -31,7 +31,8 @@
       "*.kampyle.com",
       "js.driftt.com",
       "https://rum.hlx.page/",
-      "https://*.hotjar.com"
+      "https://*.hotjar.com",
+      "*.tt.omtrdc.net"
   ],
   "connect-src": [
       "'self'",
@@ -74,7 +75,8 @@
     "cdn.cookielaw.org",
     "cm.everesttech.net",
     "*.medallia.com",
-    "*.kampyle.com"
+    "*.kampyle.com",
+    "*.salesloft.com"
   ],
   "frame-src": [
     "'self'",

--- a/scripts/csp.json
+++ b/scripts/csp.json
@@ -101,7 +101,8 @@
     "assets.adobedtm.com",
     "cdn.cookielaw.org",
     "*.medallia.com",
-    "*.kampyle.com"
+    "*.kampyle.com",
+    "*.tt.omtrdc.net"
   ],
   "font-src": [
     "'self'",


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) or JIRA ticket your PR is for, as well as test URLs where your change can be observed (before and after): -->

<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes - https://github.com/hlxsites/merative2/issues/289

## Description

**Changed**

- This PR updates both CSPs on Franklin to allow for `*.tt.omtrdc.net` and `*.salesloft.com`
- See screenshots for the current issues.

<img width="1981" alt="image" src="https://github.com/hlxsites/merative2/assets/111377779/6eda6f9f-9729-4d77-915b-0b79ce8582b9">

<img width="1990" alt="image" src="https://github.com/hlxsites/merative2/assets/111377779/f54a8119-4dbd-4f06-a83d-77281e2d1a75">

## Design Specs

- Figma Link - N/A

## Test URLs
  
- Before (Changes from `main`): https://main--merative2--hlxsites.hlx.page/
- After (Changes from this PR): https://289-chore-update-csp--merative2--proeung.hlx.page
  
## Testing Instruction

- No testing instruction is needed.
