### PR TITLE
feat(pdf-viewer): remove download button if download-pdf is false

### DIFF
--- a/blocks/leadspace/leadspace.js
+++ b/blocks/leadspace/leadspace.js
@@ -228,15 +228,26 @@ export default function decorate(block) {
         block.prepend(docTagContainer);
       }
 
+      // Get the document URL and downloadPDF value using getMetadata
       const docUrl = getMetadata('document-link');
-      if (docUrl) {
+      const downloadPDF = getMetadata('download-pdf');
+
+      // Check if docUrl exists and downloadPDF is not 'false'
+      if (docUrl && downloadPDF !== 'false') {
+        // Create the download link elements
         const downloadLinkContainer = createTag('p', { class: 'button-container' });
         const downloadLink = createTag('a', { class: 'button tertiary has-icon' });
+
+        // Set the link attributes
         downloadLink.setAttribute('href', docUrl);
         downloadLink.setAttribute('target', '_blank');
         downloadLink.textContent = 'Download PDF';
+
+        // Append the link to the container and the container to the block
         downloadLinkContainer.append(downloadLink);
         block.append(downloadLinkContainer);
+
+        // Decorate the buttons and icons
         decorateButtons(block, { decorateClasses: false, excludeIcons: [] });
         decorateIcons(block);
       }


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) or JIRA ticket your PR is for, as well as test URLs where your change can be observed (before and after): -->

<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes - https://jira.sdlc.merative.com/browse/MERATIVE-797

## Description

**Changed**
- Remove the PDF Download button if the `download-pdf` metadata is set to false.
- This request came about because the Health Insights team wants to use this new whitepaper they created, but they want to make it so a user can't download the PDF. They're concerned competitors will share with their colleagues and will inhibit lead gen. We received a request to disable the Download PDF CTA on the page.

## Design Specs

- Figma Link - N/A

## Test URLs
  
- Before (Changes from `main`): https://main--merative2--hlxsites.hlx.page/documents/white-paper/payers-weight-loss-drugs
- After (Changes from this PR): https://feat-797-pdf-viewer--merative2--proeung.hlx.page/documents/white-paper/payers-weight-loss-drugs
  
## Testing Instruction

> If applicable, please describe the tests that you ran to verify your changes. Provide instructions and link to the `hlx` deploy preview so that QA and the design team can provide proper testing.

- Visit this page (https://feat-797-pdf-viewer--merative2--proeung.hlx.page/documents/white-paper/payers-weight-loss-drugs).
- Ensure that the download button is not visible when he `download-pdf` metadata is set to false.
![Screen Shot 2023-07-20 at 11 50 25 AM](https://github.com/hlxsites/merative2/assets/1815714/697be0b3-7b61-48a2-810d-bc90de876123)

