### PR TITLE
fix(history): add missing doctype

### DIFF
--- a/resources/history/index.html
+++ b/resources/history/index.html
@@ -1,4 +1,4 @@
-fh<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <!-- OneTrust Cookies Consent Notice start for merative.com -->

--- a/resources/history/index.html
+++ b/resources/history/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+fh<!DOCTYPE html>
 <html lang="en">
   <head>
     <!-- OneTrust Cookies Consent Notice start for merative.com -->
@@ -60,7 +60,7 @@
               <h2>1973</h2>
               <h3>Point-of-care clinical decision support</h3>
               <p>Micromedex&reg; is established with the introduction of Poisindex, a toxicology information database. Today, Micromedex includes evidence-based information on drugs, diseases, toxicology and alternative medicine — plus the search efficiency of AI.</p>
-              <a href="https://www.merative.com/clinical-decision-support.html" target="_blank">Explore Micromedex</a>
+              <a href="https://www.merative.com/clinical-decision-support" target="_blank">Explore Micromedex</a>
             </div>
             <div class="content line">
               <img class="fadeInPls" src="images/1973-2.png" alt="A screenshot of Micromedex mobile app" />
@@ -79,7 +79,7 @@
               <h2>1981</h2>
               <h3>Trusted healthcare analytics</h3>
               <p>System2, later renamed Advantage Suite by Truven Health Analytics, is founded. The solution provides robust analytics for employers, health plans and Medicaid agencies. Health Insights (as it is known today) is currently used and trusted by more than 40% of Fortune 100 companies.</p>
-              <a href="https://www.merative.com/healthcare-analytics.html" target="_blank">Explore Health Insights</a>
+              <a href="https://www.merative.com/healthcare-analytics" target="_blank">Explore Health Insights</a>
             </div>
             <div class="content line">
               <div class="counter fadeInPls">
@@ -106,7 +106,7 @@
               <h2>1989</h2>
               <h3>A premier source of real-world evidence</h3>
               <p>MarketScan&reg; — one of the largest collections of proprietary, de-identified clinical and claims data in the U.S. — is established. The database includes more than 273 million unique patient records, and is used by health organizations to generate real-world evidence to support research and decision-making.</p>
-              <a href="https://www.merative.com/real-world-evidence.html" target="_blank">Explore MarketScan</a>
+              <a href="https://www.merative.com/real-world-evidence" target="_blank">Explore MarketScan</a>
             </div>
             <div class="content line">
               <div class="image-counter fadeInPls">
@@ -131,7 +131,7 @@
               <h2>1990</h2>
               <h3>Creation of medical imaging standard</h3>
               <p>Merge Healthcare, the source of Merative’s expansive enterprise imaging solutions, participates in the process to establish DICOM as the standard format for medical images. The DICOM standard is still used across the industry today.</p>
-              <a href="https://www.merative.com/merge-imaging.html" target="_blank">Explore Merge solutions</a>
+              <a href="https://www.merative.com/merge-imaging" target="_blank">Explore Merge solutions</a>
             </div>
             <div class="content line">
               <div class="lines fadeInPls">
@@ -162,7 +162,7 @@
               <h2>1995</h2>
               <h3>Award-winning cardiology solutions</h3>
               <p>Merge Cardio, an image and information management system that supports cardiology modalities, is established. Five years later, Merge Hemo, an automated documentation tool for the cardiac cath lab, is founded. Merge Cardio was named Best in KLAS for seven consecutive years, while Merge Hemo has been a KLAS Category Leader for ten years.</p>
-              <a href="https://www.vimeo.com/721076300.html" target="_blank">See how they work</a>
+              <a href="https://youtu.be/vPMKMP8JN9I" target="_blank">See how they work</a>
             </div>
             <div class="content line">
               <div class="image-steps">
@@ -193,7 +193,7 @@
               <h2>2010</h2>
               <h3>Comprehensive clinical development</h3>
               <p>The first clinical trial goes live on Merge e-Clinical Operating System, an end-to-end clinical trial management solution now known as Merative Clinical Development. To date, more than 3,400 studies in 109 countries have been generated on the solution.</p>
-              <a href="https://www.merative.com/clinical-development.html" target="_blank">Explore Clinical Development</a>
+              <a href="https://www.merative.com/clinical-development" target="_blank">Explore Clinical Development</a>
             </div>
             <div class="content line">
               <div class="steps">

--- a/resources/history/index.html
+++ b/resources/history/index.html
@@ -1,5 +1,5 @@
+<!DOCTYPE html>
 <html lang="en">
-
   <head>
     <!-- OneTrust Cookies Consent Notice start for merative.com -->
     <script type="text/javascript" src="https://cdn.cookielaw.org/consent/8ec6325b-122f-4c25-93ea-b311a7f0ef97/OtAutoBlock.js" ></script>


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) or JIRA ticket your PR is for, as well as test URLs where your change can be observed (before and after): -->

<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes - https://jira.sdlc.merative.com/browse/MERATIVE-803

## Description
**Changed**

- This adds in the missing `<!DOCTYPE html> ` tag. This was missing when we migrated the History static page from ibm.com to merative.com
- 
## Design Specs

- Figma Link - https://www.figma.com/file/dFJwrp6VkUMSirF2KMLRMx/Thought-leadership-library?type=design&node-id=787-25468&mode=design&t=pRNHGuEjJwkvu9Sy-0

## Test URLs


- Before (Changes from `feat/thought-leadership`): https://main--merative2--hlxsites.hlx.page/resources/history/index.html

![Screenshot 2023-07-31 at 11 09 15 AM](https://github.com/hlxsites/merative2/assets/1815714/97fb40ab-9426-4dcd-9321-34b76eb76fde)


- After (Changes from this PR): https://fix-merative-history-803--merative2--proeung.hlx.page/resources/history/index.html
  
## Testing Instruction

- Visit this page (https://fix-merative-history-803--merative2--proeung.hlx.page/resources/history/index.html)
- Inspect the page source and ensure that `<!DOCTYPE html> ` is visible on the top of the page doc.