### PR TITLE
feat(content): add Content block and cleanup

### DIFF
--- a/blocks/content-intro/content-intro.css
+++ b/blocks/content-intro/content-intro.css
@@ -23,7 +23,7 @@ p.content-intro__eyebrow {
   text-transform: uppercase;
   font-size: var(--font-size-11);
   font-weight: 500;
-  letter-spacing: 0.175rem;
+  letter-spacing: var(--letter-spacing-02-em);
   margin: 0 0 var(--spacer-element-07) 0;
 }
 
@@ -45,7 +45,7 @@ p.content-intro__eyebrow {
     display: flex;
     align-items: flex-start;
     flex-shrink: 0;
-    gap: 120px;
+    gap: var(--gap-120);
     max-width: 1128px;
   }
 

--- a/blocks/content/content.css
+++ b/blocks/content/content.css
@@ -34,13 +34,12 @@
   padding-inline-start: 0;
   font-size: var(--font-size-16);
   line-height: var(--line-height-160);
-  max-width: 456px;
 }
 
 .content .content__col ul li {
   position: relative;
   list-style: none;
-  padding-inline-start: var(--spacer-element-09);
+  padding-inline-start: calc(var(--spacer-element-01) + var(--spacer-element-08));
   margin: 0 0 var(--spacer-element-05) 0;
 }
 
@@ -68,7 +67,7 @@
 }
 
 .content .content__col p.button-container {
-  margin-top: var(--spacer-element-10);
+  margin-top: var(--spacer-element-08);
   margin-bottom: 0;
 }
 
@@ -76,6 +75,11 @@
 .content-complex .content .content__col p:not(.content__eyebrow) {
   font-size: var(--font-size-16);
   margin: 0 0 var(--spacer-element-03) 0;
+}
+
+.content-complex .content .content__col p:not(.content__eyebrow) strong {
+  font-size: var(--font-size-16);
+  font-family: var(--sans-serif-font-regular);
 }
 
 .content-complex .content .content__col hr {
@@ -103,11 +107,16 @@
     width: 50%;
   }
 
+  .content .content__col p.button-container {
+    margin-top: var(--spacer-element-10);
+    margin-bottom: 0;
+  }
 }
 
 /* Desktop */
 @media only screen and (min-width: 1200px) {
   .content .content__item {
+    align-items: center;
     gap: var(--gap-120);
   }
 
@@ -116,7 +125,11 @@
     margin: 0 0 var(--spacer-element-08) 0;
   }
 
-  .content .content__col p {
-    max-width: 456px;
+  .content .content__col.only-picture {
+    width: 552px;
+  }
+
+  .content .content__col {
+    width: 456px;
   }
 }

--- a/blocks/content/content.css
+++ b/blocks/content/content.css
@@ -88,7 +88,7 @@
 }
 
 .content-complex .content .content__col p.button-container {
-  margin-top: var(--spacer-element-10);
+  margin-top: var(--spacer-element-08);
   margin-bottom: 0;
 }
 
@@ -131,5 +131,9 @@
 
   .content .content__col {
     width: 456px;
+  }
+
+  .content-complex .content .content__col p.button-container {
+    margin-top: var(--spacer-element-10);
   }
 }

--- a/blocks/content/content.css
+++ b/blocks/content/content.css
@@ -1,0 +1,122 @@
+/* Content */
+.block.content {
+  padding-top: var(--spacer-layout-07);
+  padding-bottom: var(--spacer-layout-07);
+}
+
+.content .content__item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--gap-48);
+  flex-shrink: 0;
+  margin-bottom: var(--spacer-layout-06);
+}
+
+.content .content__item:last-child {
+  margin-bottom: 0;
+}
+
+.content .content__item .only-picture {
+  order: 2;
+}
+
+.content .content__col h2 {
+  margin: 0 0 var(--spacer-element-08) 0;
+}
+
+.content .content__col img {
+  width: 100%;
+}
+
+.content .content__col ul {
+  margin: var(--spacer-element-08) 0 0 0;
+  padding-inline-start: 0;
+  font-size: var(--font-size-16);
+  line-height: var(--line-height-160);
+  max-width: 456px;
+}
+
+.content .content__col ul li {
+  position: relative;
+  list-style: none;
+  padding-inline-start: var(--spacer-element-09);
+  margin: 0 0 var(--spacer-element-05) 0;
+}
+
+.content .content__col ul li::before {
+  content: "";
+  position: absolute;
+  top: var(--spacer-element-01);
+  left: 0;
+  background: url('../../icons/circular-checkmark.svg') no-repeat;
+  width: var(--spacer-element-07);
+  height: var(--spacer-element-07);
+}
+
+.content .content__col ul li:last-child {
+  margin-bottom: 0;
+}
+
+.content .content__col p.content__eyebrow {
+  font-family: var(--sans-serif-font-medium);
+  text-transform: uppercase;
+  font-size: var(--font-size-11);
+  font-weight: 500;
+  letter-spacing: var(--letter-spacing-02-em);
+  margin: 0 0 var(--spacer-element-07) 0;
+}
+
+.content .content__col p.button-container {
+  margin-top: var(--spacer-element-10);
+  margin-bottom: 0;
+}
+
+/* Content - Complex */
+.content-complex .content .content__col p:not(.content__eyebrow) {
+  font-size: var(--font-size-16);
+  margin: 0 0 var(--spacer-element-03) 0;
+}
+
+.content-complex .content .content__col hr {
+  margin: var(--spacer-element-05) 0;
+  border-width: 0;
+}
+
+.content-complex .content .content__col p.button-container {
+  margin-top: var(--spacer-element-10);
+  margin-bottom: 0;
+}
+
+/* Tablet */
+@media only screen and (min-width: 768px) {
+  .content .content__item {
+    flex-direction: row;
+    gap: var(--gap-84);
+  }
+
+  .content .content__item .only-picture {
+    order: inherit;
+  }
+
+  .content .content__col {
+    width: 50%;
+  }
+
+}
+
+/* Desktop */
+@media only screen and (min-width: 1200px) {
+  .content .content__item {
+    gap: var(--gap-120);
+  }
+
+  .content .content__col p.content__eyebrow {
+    font-size: var(--font-size-14);
+    margin: 0 0 var(--spacer-element-08) 0;
+  }
+
+  .content .content__col p {
+    max-width: 456px;
+  }
+}

--- a/blocks/content/content.js
+++ b/blocks/content/content.js
@@ -24,6 +24,5 @@ export default function decorate(block) {
         }
       }
     });
-
   });
 }

--- a/blocks/content/content.js
+++ b/blocks/content/content.js
@@ -1,0 +1,29 @@
+export default function decorate(block) {
+  [...block.children].forEach((element) => {
+    element.classList.add('content__item');
+
+    // Find all the div elements within the elements with class 'content__item'
+    const itemElements = element.querySelectorAll('.content__item div');
+
+    // Add the class 'content-intro__col' and append a number to each of these div elements
+    let counter = 1;
+    itemElements.forEach((divElement) => {
+      const newClass = `content__col-${counter}`;
+      divElement.classList.add('content__col', newClass);
+      counter += 1; // Use prefix notation to increment the counter
+
+      // Find the <h2> element inside each .content__item div
+      const h2Element = divElement.querySelector('h2');
+
+      if (h2Element) {
+        // Find the previous sibling of <h2> element
+        const previousElement = h2Element.previousElementSibling;
+
+        if (previousElement && previousElement.tagName.toLowerCase() === 'p') {
+          previousElement.classList.add('content__eyebrow');
+        }
+      }
+    });
+
+  });
+}

--- a/blocks/library-metadata/library-metadata.css
+++ b/blocks/library-metadata/library-metadata.css
@@ -1,0 +1,4 @@
+/* Metadata Wrapper - Hide */
+.library-metadata-wrapper {
+  display: none;
+}

--- a/icons/circular-checkmark.svg
+++ b/icons/circular-checkmark.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="24" height="24" rx="12" fill="#9900FF"/>
+<path d="M17.5 8.75L10.8333 15.4167L7.5 12.0833" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -163,7 +163,6 @@
   --letter-spacing-001-em: 0.01em;
   --letter-spacing-02-em: 0.2em;
 
-
   /* element spacers */
   --spacer-element-01: 2px;
   --spacer-element-02: 4px;
@@ -192,6 +191,11 @@
   --nav-height-mobile: 93px;
   --nav-height-mobile-section: 93px;
   --sticky-nav-height: 80px;
+
+  /* gap spacers */
+  --gap-48: 48px;
+  --gap-84: 84px;
+  --gap-120: 120px;
 
   /* section widths */
   --section-width-desktop: 1128px;


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) or JIRA ticket your PR is for, as well as test URLs where your change can be observed (before and after): -->

<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes - https://jira.sdlc.merative.com/browse/MERATIVE-778

## Description

**New**

- This PR adds a new block called "Content" `/blocks/content` as well as cleaning up styles and temporarily hiding the meta wrapper block that's designed for the new upgrade version of the block library.
- Variations
  - Content - Simple
  - Content - Checklist
  - Content - Complex

## Design Specs

- Figma Link - https://www.figma.com/file/vw24IPXXt4vCh9BNumka9A/Web--Merative-Digital-Design-System-2.0?type=design&node-id=1634%3A13852&mode=design&t=v6xSx8pIiPAF0sDO-1

## Test URLs

- Before (Changes from `main`): https://main--merative2--hlxsites.hlx.page/block-library/blocks/content
- After (Changes from this PR): https://feat-content-block--merative2--proeung.hlx.page/block-library/blocks/content

![Screenshot 2023-08-07 at 4 09 08 PM](https://github.com/hlxsites/merative2/assets/1815714/be2b8cca-b0b4-47e4-8956-1d5c384c42e1)

## Testing Instruction

- Visit the preview page of the "Content" Block - https://feat-content-block--merative2--proeung.hlx.page/block-library/blocks/content
- Ensure that the following variations match with the design (see Figma link)
  - Content - Simple
  - Content - Checklist
  - Content - Complex

