### PR TITLE
fix(csp): update CSP to include Bing advertising script

### DIFF
--- a/scripts/csp.json
+++ b/scripts/csp.json
@@ -34,7 +34,8 @@
       "https://*.hotjar.com",
       "*.tt.omtrdc.net",
       "*.spotify.com",
-      "embed.podcasts.apple.com"
+      "embed.podcasts.apple.com",
+      "bat.bing.com"
   ],
   "connect-src": [
       "'self'",
@@ -78,7 +79,8 @@
     "cm.everesttech.net",
     "*.medallia.com",
     "*.kampyle.com",
-    "*.salesloft.com"
+    "*.salesloft.com",
+    "bat.bing.com"
   ],
   "frame-src": [
     "'self'",


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) or JIRA ticket your PR is for, as well as test URLs where your change can be observed (before and after): -->

<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes - https://jira.sdlc.merative.com/browse/MERATIVE-820

## Description

**Changed**

- This PR updates both CSPs on Franklin to allow for `bat.bing.com` to enable Bing advertising for our paid media program.


## Design Specs

- Figma Link - N/A

## Test URLs
  
- Before (Changes from `main`): https://main--merative2--hlxsites.hlx.page/
- After (Changes from this PR): https://fix-csp-bing-advertising--merative2--proeung.hlx.page
  
## Testing Instruction

- No testing instruction is needed.
