### PR TITLE
fix(content-sidebar): adjust the font size for unordered & ordered lists

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1310,6 +1310,13 @@ main .section.section-content-body > div:last-child {
   margin-top: 0;
 }
 
+/* Section - Content body with sidebar text */
+.section-content-body.section-with-sidebar .section-content-body__text .default-content-wrapper p,
+.section-content-body.section-with-sidebar .section-content-body__text .default-content-wrapper ul,
+.section-content-body.section-with-sidebar .section-content-body__text .default-content-wrapper ol {
+  font-size: var(--font-size-16);
+}
+
 /* Section - Content body with Read more/less button */
 .section-content-body .section-content-body__text.show-more {
   border-bottom: 1px solid var(--neutral-sand);


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) or JIRA ticket your PR is for, as well as test URLs where your change can be observed (before and after): -->

<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes - https://jira.sdlc.merative.com/browse/MERATIVE-863

## Description

**Changed**

- This PR updates the correct font-size for the `<ul>` and `<ol>` lists

## Design Specs

- Figma Link - N/A

## Test URLs

![Screenshot 2023-08-21 at 4 11 43 PM](https://github.com/hlxsites/merative2/assets/1815714/5b08f4b0-442c-4673-85e7-9b276d8457f8)

- Before (Changes from `main`): https://main--merative2--hlxsites.hlx.page/events/2023-zelta-user-conference#registration-form

![Screenshot 2023-08-21 at 4 12 06 PM](https://github.com/hlxsites/merative2/assets/1815714/5da5151a-32b7-4d07-98a9-39a539c13ba2)

- After (Changes from this PR): https://fix-863-sidebar-bulleted-list--merative2--proeung.hlx.page/events/2023-zelta-user-conference#registration-form
  
## Testing Instruction

- Enable this deploy preview URL (https://fix-863-sidebar-bulleted-list--merative2--proeung.hlx.page/events/2023-zelta-user-conference#registration-form)
- Ensure that the font size is `16px`
