### PR TITLE
chore(csp): enable LinkedIn Advertising script

### DIFF
--- a/scripts/csp.json
+++ b/scripts/csp.json
@@ -36,7 +36,8 @@
       "*.spotify.com",
       "embed.podcasts.apple.com",
       "bat.bing.com",
-      "https://www.clarity.ms"
+      "https://www.clarity.ms",
+      "*.licdn.com"
   ],
   "connect-src": [
       "'self'",
@@ -62,7 +63,8 @@
       "https://*.hotjar.com",
       "https://*.hotjar.io",
       "wss://*.hotjar.com",
-      "*.clarity.ms"
+      "*.clarity.ms",
+      "*.licdn.com"
   ],
   "img-src": [
     "'self'",
@@ -83,7 +85,8 @@
     "*.kampyle.com",
     "*.salesloft.com",
     "bat.bing.com",
-    "*.clarity.ms"
+    "*.clarity.ms",
+    "*.licdn.com"
   ],
   "frame-src": [
     "'self'",


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) or JIRA ticket your PR is for, as well as test URLs where your change can be observed (before and after): -->

<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes - https://jira.sdlc.merative.com/browse/MERATIVE-864

## Description

**Changed**

- This PR updates both CSPs on Franklin to allow for `*.licdn.com` to enable LinkedIn advertising insights.


## Design Specs

- Figma Link - N/A

## Test URLs
  
- Before (Changes from `main`): https://main--merative2--hlxsites.hlx.page/
- After (Changes from this PR): https://chore-864-csp--merative2--proeung.hlx.page
  
## Testing Instruction

- Visit this deploy preview URL (https://chore-864-csp--merative2--proeung.hlx.page)
- Ensure that there's no CSP error in the console