### PR TITLE
chore(csp): enable google doubleclick in img-src

### DIFF
--- a/scripts/csp.json
+++ b/scripts/csp.json
@@ -84,9 +84,10 @@
     "*.medallia.com",
     "*.kampyle.com",
     "*.salesloft.com",
-    "bat.bing.com",
+    "*.bing.com",
     "*.clarity.ms",
-    "px.ads.linkedin.com"
+    "px.ads.linkedin.com",
+    "googleads.g.doubleclick.net"
   ],
   "frame-src": [
     "'self'",


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) or JIRA ticket your PR is for, as well as test URLs where your change can be observed (before and after): -->

<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes - https://jira.sdlc.merative.com/browse/MERATIVE-869

## Description

**Changed**

- This PR updates both CSPs on Franklin to allow for `googleads.g.doubleclick.net` and fix `*.bing.com` load error in the console.


## Design Specs

- Figma Link - N/A

## Test URLs
  
- Before (Changes from `main`): https://main--merative2--hlxsites.hlx.page/
- After (Changes from this PR): https://chore-csp-869--merative2--proeung.hlx.page
  
## Testing Instruction

- Not sure how to test this as the script looks to be loaded just for the LIVE domain name (https://www.merative.com/thank-you). Perhaps, we need to adjust the domain listing via Google Ads to point to (https://chore-csp-869--merative2--proeung.hlx.page/thank-you) to ensure that CSP is not blocking anything? @scottbridgeman Let me know what you think.