### PR TITLE
feat(sidebar-column): sidebar column width and gap changes

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1941,7 +1941,6 @@ body.quick-links main .section > div {
   /* Section - Content body with sidebar text */
   main > .section-content-body.section-with-sidebar {
     flex-direction: row-reverse;
-    gap: var(--gap-216);
   }
 
   .section-content-body.section-with-sidebar .section-content-body__form {
@@ -1950,7 +1949,8 @@ body.quick-links main .section > div {
 
   main .section-content-body.section-with-sidebar > div:first-child,
   .section-content-body.section-with-sidebar .section-content-body__text {
-    width: 264px;
+    width: var(--sidebar-max-container);
+    max-width: var(--sidebar-max-container);
   }
 
   /* Section - Content body with Read more/less button */


### PR DESCRIPTION

## Issue Sidebar column width and gap to be changed from 216px to 120px

Fixes #<gh-issue-id> [MERATIVE-873](https://jira.sdlc.merative.com/browse/MERATIVE-873)

## Description

We need to ensure that the sidebar column within the body content area is set to the width and grid count defined the the Figma specs.
All sidebar column should have a max-width of 360px (4 cols) and a gap spacing of 120px

**Changed**

All sidebar column should have a max-width of 360px (4 cols) and a gap spacing of 120px


## Design Specs


- Figma Link - https://www.figma.com/file/lcNLadWizxvzfhBpqds4hU/Curam---State-Microsite?type=design&node-id=429-2958&mode=design&t=L8R34rPdcBSP5qae-4

## Test URLs
  
- Before (Changes from `main`):https://main--merative2--sahmad-merative.hlx.page/offers/contact-curam
- After (Changes from this PR): https://873-sidebar-column--merative2--sahmad-merative.hlx.page/offers/contact-curam
  
## Testing Instruction
<img width="1414" alt="image" src="https://github.com/hlxsites/merative2/assets/135624814/9cc15794-96bb-48d6-98f0-fc29fbd01464">
- 
