### PR TITLE
fix(headshot-list): hide social links if value is 0/null

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -633,7 +633,7 @@ export function createHeadshotList(row, styles) {
   // Socials
   const socialLinks = [];
 
-  if (row.twitter) {
+  if (row.twitter && row.twitter !== '0') {
     socialLinks.push({
       href: row.twitter,
       label: 'Open Twitter',
@@ -641,7 +641,7 @@ export function createHeadshotList(row, styles) {
     });
   }
 
-  if (row.linkedin) {
+  if (row.linkedin && row.linkedin !== '0') {
     socialLinks.push({
       href: row.linkedin,
       label: 'Open LinkedIn',


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) or JIRA ticket your PR is for, as well as test URLs where your change can be observed (before and after): -->

<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes - https://jira.sdlc.merative.com/browse/MERATIVE-890

## Description

**Changed**

- This PR hides social media buttons within the Headshot List block if the value is `0` or `null`.


## Design Specs

- Figma Link - N/A

## Test URLs
  
- Before (Changes from `main`): https://main--merative2--hlxsites.hlx.page/webinars/2023-transparency-in-coverage-rule
- After (Changes from this PR): https://fix-890-headshot-list--merative2--proeung.hlx.page/webinars/2023-transparency-in-coverage-rule
  
## Testing Instruction

![Screenshot 2023-09-11 at 3 16 42 PM](https://github.com/hlxsites/merative2/assets/1815714/c2e91a8a-6966-480d-8648-f3cbbc502df7)


- Visit this page - https://fix-890-headshot-list--merative2--proeung.hlx.page/webinars/2023-transparency-in-coverage-rule
- When the speaker's bio doesn't contain a social link, the social buttons should not show up.
