### PR TITLE
chore(csp): allow googlesyndication and doubleclick

### DIFF
--- a/scripts/csp.json
+++ b/scripts/csp.json
@@ -37,7 +37,8 @@
       "embed.podcasts.apple.com",
       "bat.bing.com",
       "https://www.clarity.ms",
-      "*.licdn.com"
+      "*.licdn.com",
+      "*.googlesyndication.com"
   ],
   "connect-src": [
       "'self'",
@@ -64,7 +65,8 @@
       "https://*.hotjar.io",
       "wss://*.hotjar.com",
       "*.clarity.ms",
-      "cdn.linkedin.oribi.io"
+      "cdn.linkedin.oribi.io",
+      "*.googlesyndication.com"
   ],
   "img-src": [
     "'self'",
@@ -87,7 +89,8 @@
     "*.bing.com",
     "*.clarity.ms",
     "px.ads.linkedin.com",
-    "googleads.g.doubleclick.net"
+    "googleads.g.doubleclick.net",
+    "*.doubleclick.net"
   ],
   "frame-src": [
     "'self'",

--- a/scripts/csp.json
+++ b/scripts/csp.json
@@ -89,8 +89,7 @@
     "*.bing.com",
     "*.clarity.ms",
     "px.ads.linkedin.com",
-    "googleads.g.doubleclick.net",
-    "*.doubleclick.net"
+    "googleads.g.doubleclick.net"
   ],
   "frame-src": [
     "'self'",
@@ -104,7 +103,8 @@
     "merative.demdex.net",
     "*.medallia.com",
     "*.kampyle.com",
-    "js.driftt.com"
+    "js.driftt.com",
+    "*.doubleclick.net"
   ],
   "style-src": [
     "'self'",

--- a/scripts/csp.json
+++ b/scripts/csp.json
@@ -66,7 +66,8 @@
       "wss://*.hotjar.com",
       "*.clarity.ms",
       "cdn.linkedin.oribi.io",
-      "*.googlesyndication.com"
+      "*.googlesyndication.com",
+      "https://google.com"
   ],
   "img-src": [
     "'self'",


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) or JIRA ticket your PR is for, as well as test URLs where your change can be observed (before and after): -->

<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes - https://jira.sdlc.merative.com/browse/MERATIVE-891

## Description

**Changed**

- This PR updates both CSPs on Franklin to allow for `googlesyndication` and `doubleclick.net` that are part of google ads.


## Design Specs

- Figma Link - N/A

## Test URLs
  
- Before (Changes from `main`): https://main--merative2--hlxsites.hlx.page/
- After (Changes from this PR): https://chore-csp-891--merative2--proeung.hlx.page
  
## Testing Instruction

- Visit this deploy preview URL (https://chore-csp-891--merative2--proeung.hlx.page)
- Ensure that there's no CSP error in the console
- NOTE: Disregard the error from Drift since this is a test Franklin deploy preview.

![Screenshot 2023-09-13 at 3 04 20 PM](https://github.com/hlxsites/merative2/assets/1815714/acb379d7-03f8-4f45-93fe-422d1871d443)
