### PR TITLE
fix(duplicate-entries): removed duplicate entries

### DIFF
--- a/blocks/blog-home/blog-home.js
+++ b/blocks/blog-home/blog-home.js
@@ -1,5 +1,5 @@
 import {
-  getAllBlogs, createCard, getBlogCategoryPages, createTag, sortArrayOfObjects,
+  getAllBlogs, createCard, getBlogCategoryPages, createTag, sortArrayOfObjects, removeDuplicateEnteries,
 } from '../../scripts/scripts.js';
 
 const NUM_CARDS_SHOWN_AT_A_TIME = 6;
@@ -193,7 +193,7 @@ export function refreshCards(mode) {
       if (card.hasAttribute(attribute)) {
         const filterGroupValues = card.getAttribute(attribute).split(',');
         const found = filterGroupValues.some(
-          (checkedItem) => checkedList.find((item) => item.value === checkedItem.trim()),
+          (checkedItem) => checkedList.find((item) => item.value && checkedItem.trim() && item.value.toLowerCase() === checkedItem.trim().toLowerCase()),
         );
         if (found) {
           card.removeAttribute('aria-hidden');
@@ -499,8 +499,8 @@ export default async function decorate(block) {
   // Make a call to get all blog details from the blog index
   const blogList = await getAllBlogs(category);
   const categoriesList = await getBlogCategoryPages();
-  const topics = new Set();
-  const audiences = new Set();
+  let topics = new Set();
+  let audiences = new Set();
   if (blogList.length) {
     const blogContent = createTag('div', { class: 'blog-content' });
     // Get default content in this section and add it to blog-content
@@ -546,6 +546,10 @@ export default async function decorate(block) {
       }
       blogCards.append(blogCard);
     });
+
+    // remove duplicate enteries
+    topics = removeDuplicateEnteries(topics, 'set');
+    audiences = removeDuplicateEnteries(audiences, 'set');
 
     // Full card should be clickable
     blogCards.querySelectorAll('.card-item').forEach((card) => {

--- a/blocks/blog-home/blog-home.js
+++ b/blocks/blog-home/blog-home.js
@@ -1,5 +1,6 @@
 import {
-  getAllBlogs, createCard, getBlogCategoryPages, createTag, sortArrayOfObjects, removeDuplicateEnteries,
+  getAllBlogs, createCard, getBlogCategoryPages,
+  createTag, sortArrayOfObjects, removeDuplicateEnteries,
 } from '../../scripts/scripts.js';
 
 const NUM_CARDS_SHOWN_AT_A_TIME = 6;
@@ -193,7 +194,8 @@ export function refreshCards(mode) {
       if (card.hasAttribute(attribute)) {
         const filterGroupValues = card.getAttribute(attribute).split(',');
         const found = filterGroupValues.some(
-          (checkedItem) => checkedList.find((item) => item.value && checkedItem.trim() && item.value.toLowerCase() === checkedItem.trim().toLowerCase()),
+          (checkedItem) => checkedList.find((item) => item.value && checkedItem.trim()
+          && item.value.toLowerCase() === checkedItem.trim().toLowerCase()),
         );
         if (found) {
           card.removeAttribute('aria-hidden');

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -757,6 +757,38 @@ export async function getPDFsDocuments() {
   return (result);
 }
 
+/**
+ * Remove duplicate enteries from array or set
+ * @param {Array | Set} arr Array or Set object
+ * @param {string} type Identifier to check Array or Set. Value: set or array
+ * @returns {Array | Set} Result
+ */
+export function removeDuplicateEnteries(arr, type) {
+  const mapArr = new Map();
+  let result = [];
+
+  // Check if the array empty
+  if (!arr.length && type !== 'set') {
+    return result;
+  }
+  if (!arr.size && type === 'set') {
+    return new Set([]);
+  }
+
+  arr.forEach((item) => {
+    const _key = item.toString().trim().toLowerCase();
+    if (!mapArr.has(_key)) {
+      mapArr.set(_key, item);
+    }
+  });
+  result = [...mapArr.values()];
+  if (type === 'set') {
+    result = new Set(result);
+  }
+
+  return result;
+}
+
 export function sortArrayOfObjects(arr, property, type) {
   let result = [];
   let sortedArray;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -776,9 +776,9 @@ export function removeDuplicateEnteries(arr, type) {
   }
 
   arr.forEach((item) => {
-    const _key = item.toString().trim().toLowerCase();
-    if (!mapArr.has(_key)) {
-      mapArr.set(_key, item);
+    const key = item.toString().trim().toLowerCase();
+    if (!mapArr.has(key)) {
+      mapArr.set(key, item);
     }
   });
   result = [...mapArr.values()];


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) or JIRA ticket your PR is for, as well as test URLs where your change can be observed (before and after): -->

<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes [MERATIVE-897](https://jira.sdlc.merative.com/browse/MERATIVE-897)

## Description
We're seeing duplicate topic names within the Blog filtering page (`/blog`).
This is happening because Content Authors are not using consistent sentence cases for Topics that they're adding to Sharepoint. This is largely due to the nature of Franklin where the tagging/taxonomy is associated by the string name instead of a UID.


**Changed**
Adjusted the script for comparing the topic string/value and standardize the value to sentence case so that we can consistent filtering.


- <!-- {{ changed thing }} -->

## Design Specs N/A

> If applicable, add the direct link to the design specs of the component/feature that's part of this PR.

- Figma Link - N/A

## Test URLs
  
- Before (Changes from `main`): https://main--merative2--hlxsites.hlx.page/blog
- After (Changes from this PR): https://885-duplicate-entries--merative2--sahmad-merative.hlx.page/blog
  
## Testing Instruction

> If applicable, please describe the tests that you ran to verify your changes. Provide instructions and link to the `hlx` deploy preview so that QA and the design team can provide proper testing.

- 
<img width="1284" alt="image" src="https://github.com/hlxsites/merative2/assets/135624814/527923c1-84eb-42f7-878d-8672123bbceb">

