### PR TITLE
fix: Tagger clear button

### DIFF
--- a/tools/tagger/tagger.js
+++ b/tools/tagger/tagger.js
@@ -118,6 +118,7 @@ async function init() {
     selectedTags.forEach((tag) => {
       toggleTag(tag);
     });
+    copyButton.disabled = false;
   });
 
   document.querySelector('#search').addEventListener('keyup', filter);


### PR DESCRIPTION


## Issue 349

Fixes #349 

## Test URLs
  
- Before https://main--merative2--hlxsites.hlx.page/tools/tagger/index.html
- After https://349-taggerclear--merative2--hlxsites.hlx.page/tools/tagger/index.html
  
## Testing Instruction

- Click some tags
- Click "copy"
- Click "clear"
- Now click some more tags
- Copy button should enable you to click and copy.
- Paste somewhere so you can see the output. 
- 
