### PR TITLE
assets select plugin added to config

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -20,6 +20,19 @@
           ]
         },
         {
+          "id": "asset-library",
+          "title": "AEM Assets Library",
+          "environments": [
+            "edit"
+          ],
+          "url": "https://experience.adobe.com/solutions/CQ-assets-selectors/static-assets/resources/franklin/asset-selector.html",
+          "isPalette": true,
+          "includePaths": [
+            "**.docx**"
+          ],
+          "paletteRect": "top: 50px; bottom: 10px; right: 10px; left: auto; width:400px; height: calc(100vh - 60px)"
+        },
+        {
             "id": "tagger",
             "title": "Tagger",
             "environments": [ "edit" ],


### PR DESCRIPTION
This just adds the "AEM Assets Library" button to the sidekick when you view a Word document.

## Issue

Fixes #365 

## Description

> NOTE: You won't be able to see the new button on the sidekick until this is merged.
![image](https://github.com/hlxsites/merative2/assets/3883795/d9fcf1dc-a5be-4d29-8efe-73f426cb7aa7)


## Test URLs
  
- Before (Changes from `main`): https://main--merative2--hlxsites.hlx.page/
- After (Changes from this PR): https://365-assetselect--merative2--hlxsites.hlx.page/
  
## Testing Instruction

> If applicable, please describe the tests that you ran to verify your changes. Provide instructions and link to the `hlx` deploy preview so that QA and the design team can provide proper testing.

- 
