### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ and click the button that reads "Compare & pull request".
     
 9. Stay up to date with the activity in your pull request. Maintainers will be
 reviewing your work and making comments, asking questions, and suggesting
-changes to be made before they merge your code. When you need to make a
+changes to be made before they merge your code. 
+10. When you need to make a
 change, add, commit and push to your branch normally.
     
     Once all revisions to your pull request are complete, a maintainer will

--- a/staging-robots.txt
+++ b/staging-robots.txt
@@ -1,3 +1,2 @@
 User-agent: *
-Deny: /
-Sitemap: https://stage.merative.com/sitemap-index.xml
+Disallow: /

--- a/staging-robots.txt
+++ b/staging-robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Deny: /
-Sitemap: https://staging.merative.com/sitemap-index.xml
+Sitemap: https://stage.merative.com/sitemap-index.xml


### PR DESCRIPTION
Fixed typo in the staging url

## Issue

Fix #372

## Test URLs
  
- Before: https://main--merative--hlxsites.hlx.page/
- After: https://372-robots-stage--merative2--hlxsites.hlx.page/
  
## Description
