### PR TITLE
fix: reduce cls caused by nav

### DIFF
--- a/blocks/blog-home/blog-home.css
+++ b/blocks/blog-home/blog-home.css
@@ -5,7 +5,6 @@ body[filters-open="true"] {
 
 .thought-leadership-home.main,
 .blog-home.main {
-  padding-top: var(--nav-height-mobile);
   margin: auto;
 }
 

--- a/blocks/blog-home/blog-home.css
+++ b/blocks/blog-home/blog-home.css
@@ -716,11 +716,6 @@ h5 {
 
 /* Desktop styles */
 @media only screen and (min-width: 1200px) {
-  .thought-leadership-home.main,
-  .blog-home.main {
-    padding-top: var(--nav-height-desktop);
-  }
-
   main .section.thought-leadership-home-container,
   main .section.blog-home-container {
     padding-top: var(--spacer-layout-06);

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -25,7 +25,6 @@ header nav {
   align-items: center;
   z-index: 1;
   width: 100%;
-  height: var(--nav-height-mobile);
   margin: 0 auto;
   padding: 0 24px;
   box-sizing: border-box;
@@ -103,10 +102,6 @@ header nav .nav-sections .mega-menu a.link-with-icon span.icon svg {
 
 /* mobile/tablet nav styles */
 @media only screen and (max-width: 1199px) {
-  header {
-    height: var(--nav-height-mobile);
-  }
-
   header nav {
     display: flex;
     justify-content: space-between;
@@ -322,8 +317,6 @@ header nav .nav-sections .mega-menu a.link-with-icon span.icon svg {
   /* header */
   header {
     padding: 0;
-    max-height: 130px;
-    height: 130px;
     display: flex;
     align-items: flex-end;
   }
@@ -550,10 +543,6 @@ header nav .nav-sections .mega-menu a.link-with-icon span.icon svg {
     gap: unset;
     justify-content: unset;
     padding: var(--spacer-layout-05) calc((100vw - var(--section-width-desktop)) / 2) var(--spacer-layout-07);
-  }
-
-  header.is-sticky nav .nav-sections > ul > li[aria-expanded='true'] > ul.level-two {
-    top: var(--sticky-nav-height);
   }
 
   header nav .nav-sections > ul > li[aria-expanded='true'] > ul > li.level-two:not(.mega-menu, .featured) {

--- a/blocks/solution-header/solution-header.css
+++ b/blocks/solution-header/solution-header.css
@@ -473,17 +473,8 @@ body.microsites.header-visible main {
   }
 
   /* Sticky - Solution Header */
-  body.microsites.header-visible main {
-    padding-top: var(--nav-height-desktop);
-  }
-  
   .solution-header-wrapper {
     border-bottom: 1px solid var(--neutral-sand);
-    height: var(--nav-height-desktop);
-  }
-
-  .solution-header-wrapper.is-sticky {
-    height: var(--sticky-nav-height);
   }
 
   .solution-header-wrapper.is-sticky .solution-header__inner {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -541,16 +541,17 @@ body.appear {
 }
 
 body main {
-  margin-top: var(--nav-height-mobile);
+  padding-top: var(--nav-height-mobile);
 }
 
 header {
+  position: fixed;
   height: var(--nav-height-mobile);
 }
 
 @media (min-width: 1200px) {
   body main {
-    margin-top: var(--nav-height-desktop);
+    padding-top: var(--nav-height-desktop);
   }
 
   header {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -545,6 +545,21 @@ body.header-visible main {
   padding-top: var(--nav-height-mobile);
 }
 
+header {
+  height: var(--nav-height-mobile);
+}
+
+@media (min-width: 1200px) {
+  /* Add padding-top when Header Nav is visible */
+  body.header-visible main {
+    padding-top: var(--nav-height-desktop);
+  }
+
+  header {
+    height: var(--nav-height-desktop);
+  }
+}
+
 main {
   margin: auto;
 }
@@ -1870,11 +1885,6 @@ body.quick-links main .section > div {
     font-weight: var(--font-weight-light);
     line-height: var(--line-height-160);
     letter-spacing: var(--letter-spacing-1);
-  }
-
-  /* Add padding-top when Header Nav is visible */
-  body.header-visible main {
-    padding-top: var(--nav-height-desktop);
   }
 
   /* Section Container */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -540,9 +540,8 @@ body.appear {
   display: unset;
 }
 
-/* Add padding-top when Header Nav is visible */
-body.header-visible main {
-  padding-top: var(--nav-height-mobile);
+body main {
+  margin-top: var(--nav-height-mobile);
 }
 
 header {
@@ -550,9 +549,8 @@ header {
 }
 
 @media (min-width: 1200px) {
-  /* Add padding-top when Header Nav is visible */
-  body.header-visible main {
-    padding-top: var(--nav-height-desktop);
+  body main {
+    margin-top: var(--nav-height-desktop);
   }
 
   header {


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) or JIRA ticket your PR is for, as well as test URLs where your change can be observed (before and after): -->

<!-- Feel free to delete options that are not relevant to your PR. -->

## Description

Currently, all `header` height styles are located in `block/header/header.css`, which is lazy-loaded. This generates significant CLS when the loaded content in `main` is shoved down to accommodate the newly loaded stylesheets impacting `header` and `nav`. Proposing to move `header nav` styles impacting height into `styles.css` so circumvent this issue. Also proposing the removal of duplicative styles. 

<img width="620" alt="Screenshot 2024-04-15 at 2 06 53 PM" src="https://github.com/hlxsites/merative2/assets/43383503/06967df9-140c-43d9-966e-b0f2c7c523f6">

<img width="609" alt="Screenshot 2024-04-15 at 2 13 11 PM" src="https://github.com/hlxsites/merative2/assets/43383503/bb16d378-d645-4d10-b002-71b47992cc1b">

> Before vs. After


**Changed**

- `header nav` and `main` height set in `styles.css`, rather than in the lazy-loaded *header* block

**Removed**

- duplicative css

## Test URLs
  
- Before (Changes from `main`): [main--merative2--hlxsites.hlx.page](https://main--merative2--hlxsites.hlx.page/)
- After (Changes from this PR): [nav-cls--merative2--hlxsites.hlx.page](https://nav-cls--merative2--hlxsites.hlx.page/)
- Before (Changes from `main`): [main--merative2--hlxsites.hlx.page/clinical-development](https://main--merative2--hlxsites.hlx.page/clinical-development)
- After (Changes from this PR): [nav-cls--merative2--hlxsites.hlx.page/clinical-development](https://nav-cls--merative2--hlxsites.hlx.page/clinical-development)
- Before (Changes from `main`): [main--merative2--hlxsites.hlx.page/blog](https://main--merative2--hlxsites.hlx.page/blog)
- After (Changes from this PR): [nav-cls--merative2--hlxsites.hlx.page/blog](https://nav-cls--merative2--hlxsites.hlx.page/blog)
