### PR TITLE
Display Multiple Authors Correctly on Blog Post

### DIFF
--- a/blocks/author-bio/author-bio.css
+++ b/blocks/author-bio/author-bio.css
@@ -34,6 +34,7 @@
 @media only screen and (min-width: 768px) {
   .author-bio {
     display: flex;
+    flex-wrap: wrap;
     align-items: flex-start;
     gap: var(--spacer-element-07);
     flex-shrink: 0;


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) or JIRA ticket your PR is for, as well as test URLs where your change can be observed (before and after): -->

## Issue

Fixes: https://merative.atlassian.net/browse/MERATIVE-957

## Description

> On a blog post on desktop, if there are three authors on a post, the author block goes over the edge of the screen.

## Test URLs

- Before (Changes from `main`): https://main--merative2--hlxsites.hlx.page/drafts/Keith/3-author-blog
- After (Changes from this PR): https://issue-957-multiple-authors--merative2--hlxsites.hlx.page/drafts/Keith/3-author-blog

## Test Description
> Instead of being on the same row, a third or fourth author should display on a new line, aligned with the first two authors.