### PR TITLE
long URLs wrapped

### DIFF
--- a/blocks/references/references.css
+++ b/blocks/references/references.css
@@ -25,6 +25,7 @@
 
 .references li {
   margin: var(--spacer-element-03) 0;
+  word-break: break-word;
 }
 
 .references li::marker {


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after): -->

## Issue

Fix : https://merative.atlassian.net/browse/MERATIVE-964

## Test URLs

- Before: https://main--merative2--hlxsites.aem.page/healthcare-analytics/drafts/Keith/navigating-complexities-in-pediatric-care-copy
- After: https://issue-964-long-urls-wrap--merative2--hlxsites.hlx.page/drafts/Keith/navigating-complexities-in-pediatric-care-copy

## Description

> Currently, long URLs in the "references block" on pages do not wrap